### PR TITLE
Add empty xtask package

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --release --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,7 @@ version = 3
 [[package]]
 name = "ext4-view"
 version = "0.1.0"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,9 +7,9 @@
 # except according to those terms.
 
 [package]
-name = "ext4-view"
+name = "xtask"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
-[workspace]
-members = ["xtask"]
+[dependencies]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,11 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+fn main() {
+    todo!()
+}


### PR DESCRIPTION
This package will provide ancillary tools for the repo. See https://github.com/matklad/cargo-xtask for more background.

Also add a `cargo xtask` alias to run it.