### PR TITLE
Add std crate feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test -p ext4-view
 
+  test-std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test -p ext4-view -F std
+
   doc:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ edition = "2021"
 
 [workspace]
 members = ["xtask"]
+
+[features]
+std = []


### PR DESCRIPTION
This is not yet used, but will eventually enable std-only code such as `Error` trait impls and `File`-based reading.

Also add a CI job to test with the std feature on.