### PR TITLE
Use git-lfs for *.bin files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bin filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
In order to store test disks without blowing up the size of the repo, set up git-lfs for *.bin files. See https://git-lfs.com for more info.