### PR TITLE
Add checksum module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,8 +110,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "ext4-view"
 version = "0.1.0"
+dependencies = [
+ "crc",
+]
 
 [[package]]
 name = "gimli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ members = ["xtask"]
 
 [features]
 std = []
+
+[dependencies]
+crc = "3.0.0"

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,0 +1,89 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Stateful checksum calculator.
+///
+/// Ext4 has [metadata checksums][0] for most data structures
+/// (superblock, block group descriptor, inode, etc). The checksum
+/// algorithm more or less matches [CRC32C][1], but with the bits
+/// flipped when finalizing. When initializing with a seed, the seed's
+/// bits are reversed.
+///
+/// [0]: https://www.kernel.org/doc/html/latest/filesystems/ext4/overview.html#checksums
+/// [1]: https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-32-iscsi
+///
+/// # Seed
+///
+/// The default seed for CRC32C is `0xffff_ffff`. This is used for the
+/// superblock checksum. Other structures use a checksum seed stored in
+/// the superblock. The checksum seed is derived from the filesystem's
+/// initial UUID.
+#[derive(Clone)]
+pub(crate) struct Checksum {
+    digest: crc::Digest<'static, u32>,
+}
+
+impl Checksum {
+    /// The CRC algorithm, referred to as CRC32C in the kernel.
+    const ALGORITHM: crc::Algorithm<u32> = crc::CRC_32_ISCSI;
+
+    /// Create a `Checksum` with the default seed (`0xffff_ffff`).
+    pub(crate) fn new() -> Self {
+        Self::with_seed(Self::ALGORITHM.init)
+    }
+
+    /// Create a `Checksum` with the given `seed`.
+    pub(crate) fn with_seed(seed: u32) -> Self {
+        const CRC32C: crc::Crc<u32> =
+            crc::Crc::<u32>::new(&Checksum::ALGORITHM);
+
+        Self {
+            digest: CRC32C.digest_with_initial(seed.reverse_bits()),
+        }
+    }
+
+    /// Extend the digest with arbitrary data.
+    pub(crate) fn update(&mut self, data: &[u8]) {
+        self.digest.update(data);
+    }
+
+    /// Extend the digest with a little-endian `u16`.
+    pub(crate) fn update_u16_le(&mut self, data: u16) {
+        self.update(&data.to_le_bytes());
+    }
+
+    /// Extend the digest with a little-endian `u32`.
+    pub(crate) fn update_u32_le(&mut self, data: u32) {
+        self.update(&data.to_le_bytes());
+    }
+
+    /// Get the final value of the checksum.
+    ///
+    /// This consumes the `Checksum`.
+    pub(crate) fn finalize(self) -> u32 {
+        self.digest.finalize() ^ (!0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_checksum() {
+        let mut c = Checksum::new();
+        c.update_u32_le(1);
+        c.update_u32_le(2);
+        assert_eq!(c.finalize(), 0x858c13d3);
+
+        let mut c = Checksum::with_seed(123);
+        c.update_u32_le(1);
+        c.update_u32_le(2);
+        assert_eq!(c.finalize(), 0xfc527a0a);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,9 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
+// TODO(nicholasbishop): Temporarily allow dead code to allow for
+// smaller PRs.
+#![allow(dead_code)]
+
+mod checksum;


### PR DESCRIPTION
This will be used to perform checksum calculations for various ext4 data structures. Most of the work is done by the `crc` crate, but the kernel's way of checksumming things is just slightly different, so it's helpful to have a little wrapper.

Temporarily allow `dead_code` since the module is not used yet.