### PR TITLE
xtask: Add create-test-disk action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,134 @@
 version = 3
 
 [[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "ext4-view"
 version = "0.1.0"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "libc"
+version = "0.2.155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "xtask"
 version = "0.1.0"
+dependencies = [
+ "clap",
+ "nix",
+]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,3 +13,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
+clap = { version = "4.5.0", default-features = false, features = ["derive", "help", "std"] }
+nix = { version = "0.29.0", features = ["user"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,72 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use clap::{Parser, Subcommand};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+struct DiskParams {
+    path: PathBuf,
+    size_in_kilobytes: u32,
+}
+
+impl DiskParams {
+    fn create(&self) {
+        let uid = nix::unistd::getuid();
+        let gid = nix::unistd::getgid();
+
+        let status = Command::new("mkfs.ext4")
+            // Set the ownership of the root directory in the filesystem
+            // to the current uid/gid instead of root. That allows the
+            // mounted filesystem to be edited without root permissions,
+            // although the mount operation itself still requires root.
+            .args(["-E", &format!("root_owner={uid}:{gid}")])
+            .arg(&self.path)
+            .arg(format!("{}k", self.size_in_kilobytes))
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+}
+
+fn create_test_data() {
+    let dir = Path::new("test_data");
+    if !dir.exists() {
+        fs::create_dir(dir).unwrap();
+    }
+
+    let path = dir.join("test_disk1.bin");
+    if !path.exists() {
+        let disk = DiskParams {
+            path: path.to_owned(),
+            size_in_kilobytes: 1024 * 64,
+        };
+        disk.create();
+        // TODO(nicholasbishop): mount the filesystem and fill it with
+        // test data.
+    }
+}
+
+#[derive(Parser)]
+struct Opt {
+    #[command(subcommand)]
+    action: Action,
+}
+
+#[derive(Subcommand)]
+enum Action {
+    /// Create files for tests.
+    ///
+    /// The test files will be committed via git-lfs, so developers
+    /// working on the repo do not typically need to run this command.
+    CreateTestData,
+}
+
 fn main() {
-    todo!()
+    let opt = Opt::parse();
+
+    match &opt.action {
+        Action::CreateTestData => create_test_data(),
+    }
 }


### PR DESCRIPTION
This will be used to create test filesystems. The files will be committed with git-lfs, so everyone will share the same test data, and developers will not need to run this create-test-disk action except when creating a new test file.

This initial version just creates an empty filesystem; a later commit will mount the filesystem to add directories and files.