### PR TITLE
xtask: Set version to 0.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "xtask"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
The version really doesn't matter, this is just to help signal it's an internal package.