### PR TITLE
test_data: Add initial files

### DIFF
--- a/test_data/raw_superblock.bin
+++ b/test_data/raw_superblock.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c4209145f06e154d3d8716899eb573e7b5111cc8f5b43cec145185998420a56
+size 1024

--- a/test_data/test_disk1.bin
+++ b/test_data/test_disk1.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c8750e2f1bdd0ca58564737a674574d20afdb87fd599362659b1eb9087c2956
+size 67108864


### PR DESCRIPTION
The files were generated by running `cargo xtask create-test-data`. The output is not 100% deterministic, so the files are committed to the repo to ensure that everyone has the same test data. The files are stored with git-lfs, so they won't bloat the repo.