### PR TITLE
superblock: Drop repr(C)

### DIFF
--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -13,7 +13,6 @@ use crate::util::{read_u16le, read_u32le, u64_from_hilo};
 
 /// Information about the filesystem.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[repr(C)]
 pub struct Superblock {
     pub(crate) block_size: u32,
     pub(crate) blocks_count: u64,


### PR DESCRIPTION
In an earlier design the `Superblock` struct needed to match the on-disk layout of the superblock, so it was marked `repr(C)`. This is no longer the case; only a few fields of the superblock are stored now, so drop the `repr(C)`.