### PR TITLE
Add Ext4 struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,56 @@ mod reader;
 mod superblock;
 mod util;
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use block_group::BlockGroupDescriptor;
+use core::cell::RefCell;
+use error::Ext4Error;
+use features::ReadOnlyCompatibleFeatures;
+use superblock::Superblock;
+
 pub use reader::Ext4Read;
+
+/// Read-only access to an [ext4] filesystem.
+///
+/// [ext4]: https://en.wikipedia.org/wiki/Ext4
+pub struct Ext4 {
+    superblock: Superblock,
+    block_group_descriptors: Vec<BlockGroupDescriptor>,
+
+    /// Reader providing access to the underlying storage.
+    ///
+    /// Stored as `Box<dyn Ext4Read>` rather than a generic type to make
+    /// the `Ext4` type more convenient to pass around for users of the API.
+    ///
+    /// The `Ext4Read::read` method takes `&mut self`, because readers
+    /// like `std::fs::File` are mutable. However, the `Ext4` API is
+    /// logically const -- it provides read-only access to the
+    /// filesystem. So the box is wrapped in `RefCell` to allow the
+    /// mutable method to be called with an immutable `&Ext4`
+    /// reference. `RefCell` enforces at runtime that only one mutable
+    /// borrow exists at a time.
+    reader: RefCell<Box<dyn Ext4Read>>,
+}
+
+impl Ext4 {
+    /// Return true if the filesystem has metadata checksums enabled,
+    /// false otherwise.
+    fn has_metadata_checksums(&self) -> bool {
+        self.superblock
+            .read_only_compatible_features
+            .contains(ReadOnlyCompatibleFeatures::METADATA_CHECKSUMS)
+    }
+
+    /// Read bytes into `dst`, starting at `start_byte`.
+    fn read_bytes(
+        &self,
+        start_byte: u64,
+        dst: &mut [u8],
+    ) -> Result<(), Ext4Error> {
+        self.reader
+            .borrow_mut()
+            .read(start_byte, dst)
+            .map_err(Ext4Error::Io)
+    }
+}


### PR DESCRIPTION
This type will provide the main API for this crate. For now, only the struct itself is fully defined. A couple internal methods are defined, these will be used for reading various types within the filesystem.