### PR TITLE
block_group: Add read method

### DIFF
--- a/src/block_group.rs
+++ b/src/block_group.rs
@@ -6,8 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::checksum::Checksum;
 use crate::error::{Corrupt, Ext4Error};
+use crate::features::ReadOnlyCompatibleFeatures;
 use crate::util::{read_u16le, read_u32le, u64_from_hilo};
+use crate::Ext4;
+use alloc::vec;
 
 pub(crate) type BlockGroupIndex = u32;
 
@@ -18,6 +22,8 @@ pub(crate) struct BlockGroupDescriptor {
 }
 
 impl BlockGroupDescriptor {
+    const BG_CHECKSUM_OFFSET: usize = 0x1e;
+
     fn from_bytes(
         bgd_index: BlockGroupIndex,
         bytes: &[u8],
@@ -31,7 +37,7 @@ impl BlockGroupDescriptor {
         }
 
         let bg_inode_table_lo = read_u32le(bytes, 0x8);
-        let bg_checksum = read_u16le(bytes, 0x1e);
+        let bg_checksum = read_u16le(bytes, Self::BG_CHECKSUM_OFFSET);
         let bg_inode_table_hi = read_u32le(bytes, BG_INODE_TABLE_HI_OFFSET);
 
         let inode_table_first_block =
@@ -41,5 +47,61 @@ impl BlockGroupDescriptor {
             inode_table_first_block,
             checksum: bg_checksum,
         })
+    }
+
+    /// Read a block group descriptor.
+    pub(crate) fn read(
+        ext4: &Ext4,
+        bgd_index: BlockGroupIndex,
+    ) -> Result<BlockGroupDescriptor, Ext4Error> {
+        let sb = &ext4.superblock;
+
+        // Allocate a byte vec to read the raw data into.
+        let block_group_descriptor_size =
+            usize::from(sb.block_group_descriptor_size);
+        let mut data = vec![0; block_group_descriptor_size];
+
+        let bgd_start_block = if sb.block_size == 1024 { 2 } else { 1 };
+        let bgd_per_block =
+            sb.block_size / u32::from(sb.block_group_descriptor_size);
+        let block_index = bgd_start_block + (bgd_index / bgd_per_block);
+        let offset_within_block = (bgd_index % bgd_per_block)
+            * u32::from(sb.block_group_descriptor_size);
+
+        let start = u64::from(block_index) * u64::from(sb.block_size)
+            + u64::from(offset_within_block);
+        ext4.read_bytes(start, &mut data)?;
+
+        let block_group_descriptor =
+            BlockGroupDescriptor::from_bytes(bgd_index, &data)?;
+
+        // Verify the descriptor checksum.
+        if ext4.has_metadata_checksums() {
+            let mut checksum = Checksum::with_seed(sb.checksum_seed);
+            checksum.update_u32_le(bgd_index);
+            // Up to the checksum field.
+            checksum.update(&data[..Self::BG_CHECKSUM_OFFSET]);
+            // Zero'd checksum field.
+            checksum.update_u16_le(0);
+            // Rest of the block group descriptor.
+            checksum.update(&data[Self::BG_CHECKSUM_OFFSET + 2..]);
+            // Truncate to the lower 16 bits.
+            let checksum = checksum.finalize() as u16;
+
+            if checksum != block_group_descriptor.checksum {
+                return Err(Ext4Error::Corrupt(
+                    Corrupt::BlockGroupDescriptorChecksum(bgd_index),
+                ));
+            }
+        } else if sb
+            .read_only_compatible_features()
+            .contains(ReadOnlyCompatibleFeatures::GROUP_DESCRIPTOR_CHECKSUMS)
+        {
+            // TODO: prior to general checksum metadata being added,
+            // there was a separate feature just for block group
+            // descriptors. Add support for that here.
+        }
+
+        Ok(block_group_descriptor)
     }
 }


### PR DESCRIPTION
This method reads a block group descriptor from the underlying storage device.