### PR TITLE
Add path module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod extent;
 mod features;
 mod file_type;
 mod inode;
+mod path;
 mod reader;
 mod superblock;
 mod util;

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,30 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use alloc::vec::Vec;
+
+/// Reference path type.
+///
+/// Paths are mostly arbitrary sequences of bytes, with two restrictions:
+/// * The path cannot contain any null bytes.
+/// * Each component of the path must be no longer than 255 bytes.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Path<'a>(
+    // Use `&[u8]` rather than `[u8]` so that we don't have to use any
+    // unsafe code. Unfortunately that means we can't impl `Deref` to
+    // convert from `PathBuf` to `Path`.
+    &'a [u8],
+);
+
+/// Owned path type.
+///
+/// Paths are mostly arbitrary sequences of bytes, with two restrictions:
+/// * The path cannot contain any null bytes.
+/// * Each component of the path must be no longer than 255 bytes.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PathBuf(Vec<u8>);


### PR DESCRIPTION
This module provides `Path` and `PathBuf`. These are similar to the types of the same name in `std`. We have to provide our own types since this library can be used without std.

Since these paths are only for ext4, they are slightly more restrictive than the more general path types in `std` (see docstrings for what is allowed).

The other notable difference from `std` is that `Path` stores a reference rather than a DST. This is to avoid any `unsafe` code in the crate; DST types can't be constructed without `unsafe`.