### PR TITLE
path: Add missing test attribute

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -172,6 +172,7 @@ mod tests {
         assert_eq!(PathBuf::try_from(src), Err(PathError::ComponentTooLong));
     }
 
+    #[test]
     fn test_path_debug() {
         let src = "abc😁\n".as_bytes();
         let expected = "abc😁\\n"; // Note the escaped slash.


### PR DESCRIPTION
The compiler didn't warn about this because we have temporarily disabled unused code warnings.