### PR TITLE
Add crate metadata and a CI job to test MSRV

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,18 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          # Extract the MSRV from Cargo.toml.
+          msrv=$(cargo metadata --no-deps --format-version=1 | jq --raw-output '.packages[] | select(.name == "ext4-view") | .rust_version')
+
+          rustup toolchain install ${msrv} --profile minimal --no-self-update
+          cargo +${msrv} build -p ext4-view
+
   check:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@
 name = "ext4-view"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/nicholasbishop/ext4-view-rs"
+categories = ["filesystem", "embedded", "no-std"]
+description = "No-std compatible Rust library for reading ext4 filesystems"
+keywords = ["ext4", "filesystem", "no_std"]
 
 [workspace]
 members = ["xtask"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/nicholasbishop/ext4-view-rs"
 categories = ["filesystem", "embedded", "no-std"]
 description = "No-std compatible Rust library for reading ext4 filesystems"
 keywords = ["ext4", "filesystem", "no_std"]
+rust-version = "1.73"
 
 [workspace]
 members = ["xtask"]


### PR DESCRIPTION
This adds the usual crate metadata (URL, keywords, etc). Also sets the MSRV to 1.73 (needs to be at least 1.73 for `div_ceil`), and add a CI job to test the MSRV build. The job only builds ext4-view (doesn't run tests since we don't necessarily need test code to be restricted to the same MSRV, and doesn't build the xtask package since its deps could require a higher MSRV).