### PR TITLE
Add more Path/PathBuf impls/methods

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -75,6 +75,12 @@ impl<'a> Path<'a> {
     }
 }
 
+impl<'a> AsRef<[u8]> for Path<'a> {
+    fn as_ref(&self) -> &'a [u8] {
+        self.0
+    }
+}
+
 impl<'a> Debug for Path<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         format_bytes_debug(self.0, f)
@@ -168,6 +174,12 @@ impl PathBuf {
     /// [`Display`]: core::fmt::Display
     pub fn display(&self) -> BytesDisplay {
         BytesDisplay(&self.0)
+    }
+}
+
+impl AsRef<[u8]> for PathBuf {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
     }
 }
 
@@ -305,5 +317,16 @@ mod tests {
         assert!(!PathBuf::new(b"abc").is_absolute());
         assert!(!Path::new(b"").is_absolute());
         assert!(!PathBuf::new(b"").is_absolute());
+    }
+
+    #[test]
+    fn test_as_ref() {
+        let path = Path::new("abc");
+        let b: &[u8] = path.as_ref();
+        assert_eq!(b, b"abc");
+
+        let path = PathBuf::new("abc");
+        let b: &[u8] = path.as_ref();
+        assert_eq!(b, b"abc");
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -242,6 +242,12 @@ where
     }
 }
 
+impl<'a> From<Path<'a>> for PathBuf {
+    fn from(p: Path<'a>) -> Self {
+        PathBuf(p.0.to_vec())
+    }
+}
+
 #[cfg(all(feature = "std", unix))]
 impl From<PathBuf> for std::path::PathBuf {
     fn from(p: PathBuf) -> std::path::PathBuf {
@@ -360,5 +366,12 @@ mod tests {
         let v: &[u8] = b"abc";
         assert_eq!(path, v);
         assert_eq!(pathbuf, v);
+    }
+
+    #[test]
+    fn test_path_buf_from_path() {
+        let path = Path::new("abc");
+        let pathbuf = PathBuf::from(path);
+        assert_eq!(pathbuf, "abc");
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -145,7 +145,7 @@ impl<'a> From<Path<'a>> for &'a std::path::Path {
 /// Paths are mostly arbitrary sequences of bytes, with two restrictions:
 /// * The path cannot contain any null bytes.
 /// * Each component of the path must be no longer than 255 bytes.
-#[derive(Clone, Eq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Default, Eq, Ord, PartialOrd, Hash)]
 pub struct PathBuf(Vec<u8>);
 
 impl PathBuf {
@@ -164,6 +164,11 @@ impl PathBuf {
         P: AsRef<[u8]> + ?Sized,
     {
         Self::try_from(p.as_ref()).unwrap()
+    }
+
+    /// Create empty `PathBuf`.
+    pub const fn empty() -> Self {
+        Self(Vec::new())
     }
 
     /// Borrow as a `Path`.
@@ -291,6 +296,10 @@ mod tests {
         // Successful construction from a vector (only for PathBuf).
         let src: Vec<u8> = b"abc".to_vec();
         assert_eq!(PathBuf::try_from(src).unwrap(), expected_path_buf);
+
+        // Successful construction of empty PathBuf.
+        assert_eq!(PathBuf::empty(), []);
+        assert_eq!(PathBuf::default(), []);
 
         // Error: contains null.
         let src: &str = "\0";


### PR DESCRIPTION
Note: the `PartialEq` derives have been replaced with an explicit impl that covers a wider range of types.