### PR TITLE
Add DirEntry::path and DirEntry::file_name methods

### DIFF
--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -233,6 +233,13 @@ impl DirEntry {
         Ok((Some(entry), rec_len))
     }
 
+    /// Get the directory entry's name.
+    #[must_use]
+    #[inline]
+    pub fn file_name(&self) -> DirEntryName<'_> {
+        self.name.as_dir_entry_name()
+    }
+
     /// Get the entry's path.
     ///
     /// This appends the entry's name to the path that `Ext4::read_dir`
@@ -377,6 +384,7 @@ mod tests {
                 path: path.clone(),
             },
         );
+        assert_eq!(entry.file_name(), "abc");
         assert_eq!(entry.path(), "path/abc");
 
         // Special entry: inode is zero.


### PR DESCRIPTION
The path method makes use of a new `Rc<PathBuf>` passed into the constructor. This will come from the path passed to `read_dir` (not implemented yet). The `Rc` allows the allocation to be shared.