### PR TITLE
error: Add Incompatible::DirectoryHash

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -275,6 +275,12 @@ pub enum Incompatible {
         /// The incompatible features.
         IncompatibleFeatures,
     ),
+
+    /// The directory hash algorithm is not supported.
+    DirectoryHash(
+        /// The algorithm identifier.
+        u8,
+    ),
 }
 
 impl Display for Incompatible {
@@ -288,6 +294,9 @@ impl Display for Incompatible {
             }
             Self::Incompatible(feat) => {
                 write!(f, "incompatible features: {feat:?}")
+            }
+            Self::DirectoryHash(algorithm) => {
+                write!(f, "unsupported directory hash algorithm: {algorithm}")
             }
         }
     }


### PR DESCRIPTION
Various hash algorithms are allowed in directory htrees [1], and more could be added in the future. This error will be used if the library doesn't know how to handle the algorithm specified in a directory htree root node.

[1]: https://www.kernel.org/doc/html/latest/filesystems/ext4/globals.html#super-def-hash