### PR TITLE
xtask: Add ReadOnly option to Mount

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -15,7 +15,7 @@ use std::fs::File;
 use std::io;
 use std::path::Path;
 
-pub use mount::Mount;
+pub use mount::{Mount, ReadOnly};
 
 /// Calculate the SHA256 hash of the file at `path`.
 ///

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,7 +14,7 @@ use std::io::{Seek, SeekFrom, Write};
 use std::os::unix::fs::symlink;
 use std::path::PathBuf;
 use std::process::Command;
-use xtask::Mount;
+use xtask::{Mount, ReadOnly};
 
 /// Get the path of the root directory of the repo.
 ///
@@ -61,7 +61,7 @@ impl DiskParams {
 
     /// Put some data on the disk.
     fn fill(&self) -> Result<()> {
-        let mount = Mount::new(&self.path)?;
+        let mount = Mount::new(&self.path, ReadOnly(false))?;
         let root = mount.path();
 
         // Create an empty file.

--- a/xtask/src/mount.rs
+++ b/xtask/src/mount.rs
@@ -11,6 +11,9 @@ use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
+/// Whether to mount read-only or read-write.
+pub struct ReadOnly(pub bool);
+
 /// Mounted filesystem.
 ///
 /// The filesystem will be unmounted on drop.
@@ -22,10 +25,10 @@ impl Mount {
     /// Mount a file containing a filesystem to a temporary directory.
     ///
     /// Mounting is a privileged operation, so this runs `sudo mount`.
-    pub fn new(fs_bin: &Path) -> Result<Self> {
+    pub fn new(fs_bin: &Path, read_only: ReadOnly) -> Result<Self> {
         let mount_point = TempDir::new()?;
         let status = Command::new("sudo")
-            .args(["mount", "-o", "ro"])
+            .args(["mount", "-o", if read_only.0 { "ro" } else { "rw" }])
             .args([fs_bin, mount_point.path()])
             .status()?;
         if !status.success() {


### PR DESCRIPTION
I previously changed Mount to read-only for a different use case (part of the wip branch, not yet merged), and forgot that we also need read-write for creating/updating the test data.

Add an arg to control whether it's read-only, and update the existing mount usage to read-write.