### PR TITLE
dir_entry: Add guard for too-small record length

### DIFF
--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -207,6 +207,14 @@ impl DirEntry {
         let rec_len = read_u16le(bytes, 4);
         let rec_len = usize::from(rec_len);
 
+        // Check that the rec_len is somewhat reasonable. Too small a
+        // value could indicate the wrong data is being read. And
+        // notably, a value of zero would cause an infinite loop when
+        // iterating over entries.
+        if rec_len < NAME_OFFSET {
+            return Err(err());
+        }
+
         // As described above, an inode of zero is used for special
         // entries. Return early since the rest of the fields won't be
         // valid.


### PR DESCRIPTION
The length should always be at least 8 bytes, otherwise there wouldn't be enough space for the header fields. And a record length of zero would cause an infinite loop when reading entries. Return an error if the record length doesn't make sense to guard against bugs and malicious filesystems.