### PR TITLE
dir: Add ReadDir iterator

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,0 +1,246 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::checksum::Checksum;
+use crate::dir_entry::DirEntry;
+use crate::error::{Corrupt, Ext4Error};
+use crate::extent::{Extent, Extents};
+use crate::inode::{Inode, InodeFlags, InodeIndex};
+use crate::path::PathBuf;
+use crate::util::{read_u16le, read_u32le, usize_from_u32};
+use crate::Ext4;
+use alloc::rc::Rc;
+use alloc::vec;
+use alloc::vec::Vec;
+
+/// Iterator over each [`DirEntry`] in a directory inode.
+pub struct ReadDir<'a> {
+    fs: &'a Ext4,
+
+    /// Path of the directory. This is stored in an `Rc` so that it can
+    /// be shared with each `DirEntry` without cloning the path data.
+    ///
+    /// Note that this path may be empty, e.g. if `read_dir` was called
+    /// with an inode rather than a path.
+    path: Rc<PathBuf>,
+
+    /// Iterator over the directory's extents.
+    extents: Extents<'a>,
+
+    /// The current extent.
+    extent: Option<Extent>,
+
+    /// The index of the current block within the extent.
+    block_index: u64,
+
+    /// The current block's data.
+    block: Vec<u8>,
+
+    /// The current byte offset within the block data.
+    offset_within_block: usize,
+
+    /// Whether the iterator is done (calls to `Iterator::next` will
+    /// return `None`).
+    is_done: bool,
+
+    /// Whether the directory has an htree for fast lookups. The
+    /// iterator doesn't directly use the htree, but it affects which
+    /// blocks have checksums.
+    has_htree: bool,
+
+    /// Initial checksum using values from the directory's inode. This
+    /// serves as the seed for directory block checksums.
+    checksum_base: Checksum,
+
+    /// Inode of the directory. Just used for error reporting.
+    inode: InodeIndex,
+}
+
+impl<'a> ReadDir<'a> {
+    pub(crate) fn new(
+        fs: &'a Ext4,
+        inode: &Inode,
+        path: PathBuf,
+    ) -> Result<Self, Ext4Error> {
+        let mut checksum_base =
+            Checksum::with_seed(fs.superblock.checksum_seed);
+        checksum_base.update_u32_le(inode.index.get());
+        checksum_base.update_u32_le(inode.generation);
+
+        let has_htree = inode.flags.contains(InodeFlags::DIRECTORY_HTREE);
+
+        Ok(Self {
+            fs,
+            path: Rc::new(path),
+            extents: Extents::new(fs, inode)?,
+            extent: None,
+            block_index: 0,
+            block: vec![0; usize_from_u32(fs.superblock.block_size)],
+            offset_within_block: 0,
+            is_done: false,
+            has_htree,
+            checksum_base,
+            inode: inode.index,
+        })
+    }
+
+    // Step to the next entry.
+    //
+    // This is factored out of `Iterator::next` for clarity and ease of
+    // returning errors.
+    //
+    // When this returns `Ok(None)`, the outer loop in `Iterator::next`
+    // will call it again until it reaches an actual value.
+    fn next_impl(&mut self) -> Result<Option<DirEntry>, Ext4Error> {
+        // Get the extent, or get the next one if not set.
+        let extent = if let Some(extent) = &self.extent {
+            extent
+        } else {
+            match self.extents.next() {
+                Some(Ok(extent)) => {
+                    self.extent = Some(extent);
+                    self.block_index = 0;
+                    self.offset_within_block = 0;
+
+                    // OK to unwrap since we just set it.
+                    self.extent.as_ref().unwrap()
+                }
+                Some(Err(err)) => return Err(err),
+                None => {
+                    self.is_done = true;
+                    return Ok(None);
+                }
+            }
+        };
+
+        // If all blocks in the extent have been processed, move to the
+        // next extent on the next iteration.
+        if self.block_index == u64::from(extent.num_blocks) {
+            self.extent = None;
+            return Ok(None);
+        }
+
+        // If a block has been fully processed, move to the next block
+        // on the next iteration.
+        let block_size = self.fs.superblock.block_size;
+        if self.offset_within_block >= usize_from_u32(block_size) {
+            self.block_index += 1;
+            self.offset_within_block = 0;
+            return Ok(None);
+        }
+
+        // If at the start of a new block, read it and verify the checksum.
+        if self.offset_within_block == 0 {
+            self.fs.read_bytes(
+                (self.block_index + extent.start_block) * u64::from(block_size),
+                &mut self.block,
+            )?;
+
+            // Check if this is an internal node in an htree. If so, it
+            // doesn't have a checksum.
+            let first_rec_len = u32::from(read_u16le(&self.block, 4));
+            let is_internal_node = self.has_htree
+                && (extent.block_within_file == 0
+                    || first_rec_len == block_size);
+
+            // Verify checksum of the whole directory block.
+            if self.fs.has_metadata_checksums() && !is_internal_node {
+                let tail_entry_size = 12;
+                let tail_entry_offset =
+                    usize_from_u32(block_size) - tail_entry_size;
+                let checksum_offset = tail_entry_offset + 8;
+                let expected_checksum =
+                    read_u32le(&self.block, checksum_offset);
+
+                let mut checksum = self.checksum_base.clone();
+                checksum.update(&self.block[..tail_entry_offset]);
+                let actual_checksum = checksum.finalize();
+                if expected_checksum != actual_checksum {
+                    return Err(Ext4Error::Corrupt(Corrupt::DirBlockChecksum(
+                        self.inode.get(),
+                    )));
+                }
+            }
+        }
+
+        let (entry, entry_size) = DirEntry::from_bytes(
+            &self.block[self.offset_within_block..],
+            self.inode,
+            self.path.clone(),
+        )?;
+        self.offset_within_block += entry_size;
+
+        Ok(entry)
+    }
+}
+
+impl<'a> Iterator for ReadDir<'a> {
+    type Item = Result<DirEntry, Ext4Error>;
+
+    fn next(&mut self) -> Option<Result<DirEntry, Ext4Error>> {
+        // In pseudocode, here's what the iterator is doing:
+        //
+        // for extent in extents(inode) {
+        //   for block in extent.blocks {
+        //     verify_checksum(block);
+        //     for dir_entry in block {
+        //       yield dir_entry;
+        //     }
+        //   }
+        // }
+
+        loop {
+            if self.is_done {
+                return None;
+            }
+
+            match self.next_impl() {
+                Ok(Some(entry)) => return Some(Ok(entry)),
+                Ok(None) => {
+                    // Continue.
+                }
+                Err(err) => {
+                    self.is_done = true;
+                    return Some(Err(err));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_dir() {
+        let fs_path = std::path::Path::new("test_data/test_disk1.bin");
+        let fs = Ext4::load_from_path(fs_path).unwrap();
+
+        // Root inode is always 2.
+        let root_inode_index = InodeIndex::new(2).unwrap();
+        let root_inode = Inode::read(&fs, root_inode_index).unwrap();
+        let root_path = crate::PathBuf::new("/");
+
+        // Use the iterator to get all DirEntries in the root directory.
+        let entries: Vec<_> = ReadDir::new(&fs, &root_inode, root_path)
+            .unwrap()
+            .map(|e| e.unwrap())
+            .collect();
+
+        // Check for a few expected entries.
+        assert!(entries.iter().any(|e| e.file_name() == "."));
+        assert!(entries.iter().any(|e| e.file_name() == ".."));
+        assert!(entries.iter().any(|e| e.file_name() == "empty_file"));
+        assert!(entries.iter().any(|e| e.file_name() == "empty_dir"));
+
+        // Check for something that does not exist.
+        assert!(!entries.iter().any(|e| e.file_name() == "does_not_exist"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ extern crate alloc;
 
 mod block_group;
 mod checksum;
+mod dir;
 mod dir_entry;
 mod error;
 mod extent;
@@ -38,6 +39,7 @@ use features::ReadOnlyCompatibleFeatures;
 use superblock::Superblock;
 use util::usize_from_u32;
 
+pub use dir::ReadDir;
 pub use dir_entry::{DirEntry, DirEntryName, DirEntryNameError};
 pub use error::{Corrupt, Ext4Error, Incompatible, IoError};
 pub use features::IncompatibleFeatures;


### PR DESCRIPTION
This iterator is similar to `std::fs::ReadDir`. It yields `DirEntry`s.