### PR TITLE
Add get_dir_entry_inode_by_name

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -223,9 +223,7 @@ mod tests {
         let fs_path = std::path::Path::new("test_data/test_disk1.bin");
         let fs = Ext4::load_from_path(fs_path).unwrap();
 
-        // Root inode is always 2.
-        let root_inode_index = InodeIndex::new(2).unwrap();
-        let root_inode = Inode::read(&fs, root_inode_index).unwrap();
+        let root_inode = fs.read_root_inode().unwrap();
         let root_path = crate::PathBuf::new("/");
 
         // Use the iterator to get all DirEntries in the root directory.

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -163,7 +163,7 @@ impl TryFrom<&[u8]> for DirEntryNameBuf {
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct DirEntry {
     /// Number of the inode that this entry points to.
-    inode: InodeIndex,
+    pub(crate) inode: InodeIndex,
 
     /// Raw name of the entry.
     name: DirEntryNameBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ use block_group::BlockGroupDescriptor;
 use core::cell::RefCell;
 use extent::Extents;
 use features::ReadOnlyCompatibleFeatures;
-use inode::Inode;
+use inode::{Inode, InodeIndex};
 use superblock::Superblock;
 use util::usize_from_u32;
 
@@ -123,6 +123,12 @@ impl Ext4 {
         self.superblock
             .read_only_compatible_features
             .contains(ReadOnlyCompatibleFeatures::METADATA_CHECKSUMS)
+    }
+
+    /// Read the inode of the root `/` directory.
+    fn read_root_inode(&self) -> Result<Inode, Ext4Error> {
+        let root_inode_index = InodeIndex::new(2).unwrap();
+        Inode::read(self, root_inode_index)
     }
 
     /// Read bytes into `dst`, starting at `start_byte`.


### PR DESCRIPTION
This will be used when resolving paths. For now it does a simple linear search through all the directory entries. In the future, large directories with htrees will use a faster lookup method.

A few small related changes:
* Made the `DirEntry::inode` field `crate(pub)` so that it can be used in the `dir` module
* Added `Ext4::read_root_inode`. For now it's used in a couple tests, and in future commits it will be used for path lookup, since that starts in the root inode.