### PR TITLE
Add Ext4::path_to_inode

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -281,6 +281,10 @@ pub enum Incompatible {
         /// The algorithm identifier.
         u8,
     ),
+
+    /// A path contains symlink or ".." components, but the operation
+    /// being attempted does not supports this type of path.
+    UnresolvedPath,
 }
 
 impl Display for Incompatible {
@@ -297,6 +301,9 @@ impl Display for Incompatible {
             }
             Self::DirectoryHash(algorithm) => {
                 write!(f, "unsupported directory hash algorithm: {algorithm}")
+            }
+            Self::UnresolvedPath => {
+                write!(f, "path contains a symlink or '..'")
             }
         }
     }


### PR DESCRIPTION
This will be used to resolve paths passed into high-level APIs like `Ext4::read`.

In the future we'll want to support resolving paths passed to high-level operations such as `Ext4::read`, meaning that symlinks and '..' get resolved the same way as in Linux. However, path resolution is somewhat complicated so for now we'll just return an error if a symlink component is encountered.

(Symlinks are also a common source of logic and security bugs, so even when symlink resolution support is added, we might want to add a way to turn it on/off.)