### PR TITLE
dir: Impl Debug for ReadDir

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -17,6 +17,7 @@ use crate::Ext4;
 use alloc::rc::Rc;
 use alloc::vec;
 use alloc::vec::Vec;
+use core::fmt::{self, Debug, Formatter};
 
 /// Iterator over each [`DirEntry`] in a directory inode.
 pub struct ReadDir<'a> {
@@ -176,6 +177,14 @@ impl<'a> ReadDir<'a> {
         self.offset_within_block += entry_size;
 
         Ok(entry)
+    }
+}
+
+impl<'a> Debug for ReadDir<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // Only include the path field. This matches the Debug impl for
+        // `std::fs::ReadDir`.
+        write!(f, r#"ReadDir("{:?}")"#, self.path)
     }
 }
 


### PR DESCRIPTION
This is mostly desirable so that `unwrap` can be called on the result of `Ext4::read_dir`.

Only the `path` field is included in the output, matching the behavior of `std::fs::ReadDir`.

A test will be added in a later commit, after `Ext4::read_dir` is added.