### PR TITLE
Enable crate features on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ std = []
 [dependencies]
 bitflags = "2.0.0"
 crc = "3.0.0"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! ```
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
 // TODO(nicholasbishop): Temporarily allow dead code to allow for
 // smaller PRs.


### PR DESCRIPTION
* Enable `all-features` on docs.rs so that code gated behind `feature(std)` shows up (and if we add any other features in the future, they'll show up too).

* Add a `docsrs` config to enable `doc_auto_cfg` on docs.rs. This adds feature "badges" so that you can see if something is only available with a particular feature enabled. See for example: https://docs.rs/sbat/latest/sbat/struct.ImageSbatOwned.html: "Available on crate feature alloc only". A bare `--cfg` is used instead of a feature since it's not intended to be used outside of docs.rs.