### PR TITLE
Enable missing_docs lint

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -6,9 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use bitflags::bitflags;
-
 // TODO: fill in more docstrings.
+#![allow(missing_docs)]
+
+use bitflags::bitflags;
 
 bitflags! {
     /// File system features that affect whether the data can be read.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 // TODO(nicholasbishop): Temporarily allow dead code to allow for
 // smaller PRs.
 #![allow(dead_code)]
+#![warn(missing_docs)]
 #![warn(unreachable_pub)]
 
 extern crate alloc;


### PR DESCRIPTION
This will warn if any public items are missing a docstring. Disable it in `features.rs` for now since that still has some undocumented items.