### PR TITLE
Enable clippy::as_conversions lint

### DIFF
--- a/src/block_group.rs
+++ b/src/block_group.rs
@@ -86,7 +86,7 @@ impl BlockGroupDescriptor {
             // Rest of the block group descriptor.
             checksum.update(&data[Self::BG_CHECKSUM_OFFSET + 2..]);
             // Truncate to the lower 16 bits.
-            let checksum = checksum.finalize() as u16;
+            let checksum = u16::try_from(checksum.finalize() & 0xffff).unwrap();
 
             if checksum != block_group_descriptor.checksum {
                 return Err(Ext4Error::Corrupt(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 // TODO(nicholasbishop): Temporarily allow dead code to allow for
 // smaller PRs.
 #![allow(dead_code)]
+#![warn(clippy::as_conversions)]
 #![warn(missing_docs)]
 #![warn(unreachable_pub)]
 


### PR DESCRIPTION
This warns for any use of `as`. In general it's best to avoid `as` because it's a big hammer that can implictly do all kinds of conversions.

Also fix the one place where `as` is currently used.