### PR TITLE
Inode checksum cleanups

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -68,11 +68,6 @@ impl<'a> ReadDir<'a> {
         inode: &Inode,
         path: PathBuf,
     ) -> Result<Self, Ext4Error> {
-        let mut checksum_base =
-            Checksum::with_seed(fs.superblock.checksum_seed);
-        checksum_base.update_u32_le(inode.index.get());
-        checksum_base.update_u32_le(inode.generation);
-
         let has_htree = inode.flags.contains(InodeFlags::DIRECTORY_HTREE);
 
         Ok(Self {
@@ -85,7 +80,7 @@ impl<'a> ReadDir<'a> {
             offset_within_block: 0,
             is_done: false,
             has_htree,
-            checksum_base,
+            checksum_base: inode.checksum_base.clone(),
             inode: inode.index,
         })
     }

--- a/src/extent.rs
+++ b/src/extent.rs
@@ -149,11 +149,6 @@ impl<'a> Extents<'a> {
         ext4: &'a Ext4,
         inode: &Inode,
     ) -> Result<Self, Ext4Error> {
-        let mut checksum_base =
-            Checksum::with_seed(ext4.superblock.checksum_seed);
-        checksum_base.update_u32_le(inode.index.get());
-        checksum_base.update_u32_le(inode.generation);
-
         Ok(Self {
             ext4,
             inode: inode.index,
@@ -161,7 +156,7 @@ impl<'a> Extents<'a> {
                 inode.inline_data.to_vec(),
                 inode.index,
             )?],
-            checksum_base,
+            checksum_base: inode.checksum_base.clone(),
         })
     }
 

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -198,10 +198,7 @@ impl Inode {
 
         // Verify the inode checksum.
         if ext4.has_metadata_checksums() {
-            let mut checksum = Checksum::with_seed(sb.checksum_seed);
-
-            checksum.update_u32_le(inode.index.get());
-            checksum.update_u32_le(inode.generation);
+            let mut checksum = inode.checksum_base.clone();
 
             // Hash all the inode data, but treat the two checksum
             // fields as zeroes.


### PR DESCRIPTION
* Move the inode's stored checksum out of `struct Inode`, return it as a separate value from `Inode::read_bytes` instead.
* Add `checksum_base` to `Inode`, this is a seed used for the inode itself as well as extents and dir blocks. Update the code in other places to make use of this new field.