### PR TITLE
Add resolve module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ mod inode;
 mod metadata;
 mod path;
 mod reader;
+mod resolve;
 mod superblock;
 mod util;
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// How symlinks are treated when looking up an inode.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum FollowSymlinks {
+    /// All symlinks are followed.
+    All,
+
+    /// Symlinks are followed, except for the final component. If the
+    /// final component is a symlink, the inode for that symlink is
+    /// returned rather than the symlink's target.
+    ///
+    /// This is used for `Ext4::symlink_metadata`, which has similar
+    /// behavior to `lstat`:
+    /// https://www.man7.org/linux/man-pages/man2/lstat.2.html
+    ExcludeFinalComponent,
+}


### PR DESCRIPTION
This module will contain a revamped version of `path_to_inode`, with proper handling for ".." and symlinks.

For this initial commit, just add `FollowSymlinks`, which will control how symlinks are resolved. For why this is needed, see the difference between fs::metadata and fs::symlink_metadata:
* https://doc.rust-lang.org/std/fs/fn.metadata.html
* https://doc.rust-lang.org/std/fs/fn.symlink_metadata.html