### PR TITLE
Update and expand the top-level docstring

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc
+      - run: cargo doc -F std
         env:
           RUSTDOCFLAGS: -Dwarnings
 


### PR DESCRIPTION
Also enable the `std` feature when checking docs in CI, since there are now doclinks to stuff gated behind that feature.