### PR TITLE
Configure cargo-deny and run it in CI

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -1,0 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+[licenses]
+allow = [
+  "Apache-2.0",
+  "MIT",
+  "Unicode-DFS-2016",
+]
+
+[bans]
+multiple-versions = "deny"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,14 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo fmt --all -- --check
 
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        arguments: --workspace --all-features
+
   spellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,6 +10,7 @@
 name = "xtask"
 version = "0.0.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Also add license to `xtask/Cargo.toml` (package isn't published, but cargo-deny likes packages to have a license)