### PR TITLE
Rework Metadata so that it doesn't contain the whole inode

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -205,7 +205,7 @@ pub(crate) fn get_dir_entry_inode_by_name(
     dir_inode: &Inode,
     name: DirEntryName<'_>,
 ) -> Result<Inode, Ext4Error> {
-    assert!(dir_inode.file_type.is_dir());
+    assert!(dir_inode.metadata.is_dir());
 
     // TODO: add faster lookup by hash, if the inode has
     // InodeFlags::DIRECTORY_HTREE.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ impl Ext4 {
         let block_size = self.superblock.block_size;
 
         // Get the file size and preallocate the output vector.
-        let file_size_in_bytes = usize::try_from(inode.size_in_bytes)
+        let file_size_in_bytes = usize::try_from(inode.metadata.size_in_bytes)
             .map_err(|_| Ext4Error::FileTooLarge)?;
         let mut dst = vec![0; file_size_in_bytes];
 
@@ -316,10 +316,10 @@ impl Ext4 {
         fn inner(fs: &Ext4, path: Path<'_>) -> Result<Vec<u8>, Ext4Error> {
             let inode = fs.path_to_inode(path, FollowSymlinks::All)?;
 
-            if inode.file_type.is_dir() {
+            if inode.metadata.is_dir() {
                 return Err(Ext4Error::IsADirectory);
             }
-            if !inode.file_type.is_regular_file() {
+            if !inode.metadata.file_type.is_regular_file() {
                 return Err(Ext4Error::IsASpecialFile);
             }
 
@@ -391,7 +391,7 @@ impl Ext4 {
         ) -> Result<ReadDir<'a>, Ext4Error> {
             let inode = fs.path_to_inode(path, FollowSymlinks::All)?;
 
-            if !inode.file_type.is_dir() {
+            if !inode.metadata.is_dir() {
                 return Err(Ext4Error::NotADirectory);
             }
 
@@ -438,7 +438,7 @@ impl Ext4 {
     {
         fn inner(fs: &Ext4, path: Path<'_>) -> Result<Metadata, Ext4Error> {
             let inode = fs.path_to_inode(path, FollowSymlinks::All)?;
-            Ok(Metadata::new(inode))
+            Ok(inode.metadata)
         }
 
         inner(self, path.try_into().map_err(|_| Ext4Error::MalformedPath)?)

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -7,43 +7,46 @@
 // except according to those terms.
 
 use crate::file_type::FileType;
-use crate::inode::Inode;
+use crate::inode::InodeMode;
 
 /// Metadata information about a file.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Metadata {
-    inode: Inode,
+    /// Size in bytes of the file data.
+    pub(crate) size_in_bytes: u64,
+
+    /// Raw permissions and file type.
+    pub(crate) mode: InodeMode,
+
+    /// File type parsed from the `mode` bitfield.
+    pub(crate) file_type: FileType,
 }
 
 impl Metadata {
-    pub(crate) fn new(inode: Inode) -> Self {
-        Self { inode }
-    }
-
     /// Get the file type.
     pub fn file_type(&self) -> FileType {
-        self.inode.file_type
+        self.file_type
     }
 
     /// Return true if this metadata is for a directory.
     pub fn is_dir(&self) -> bool {
-        self.inode.file_type.is_dir()
+        self.file_type.is_dir()
     }
 
     /// Return true if this metadata is for a symlink.
     pub fn is_symlink(&self) -> bool {
-        self.inode.file_type.is_symlink()
+        self.file_type.is_symlink()
     }
 
     /// Get the size in bytes of the file.
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u64 {
-        self.inode.size_in_bytes
+        self.size_in_bytes
     }
 
     /// Get the file's UNIX permission bits.
     pub fn mode(&self) -> u32 {
-        let mode = self.inode.mode.bits() & 0xfff;
+        let mode = self.mode.bits() & 0xfff;
         // Convert from u16 to u32 to match the std `PermissionsExt` interface.
         u32::from(mode)
     }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -123,7 +123,7 @@ pub(crate) fn resolve_path(
         // Get the component name.
         let comp = &path[index..comp_end];
 
-        if !inode.file_type.is_dir() {
+        if !inode.metadata.is_dir() {
             // Can't look up a child of a non-directory;
             // path is invalid. This handles a case like
             // "/a/b", where "a" is a regular file instead
@@ -149,7 +149,7 @@ pub(crate) fn resolve_path(
             path.drain(remove_start..comp_end_with_sep);
             index = remove_start;
             inode = child_inode;
-        } else if child_inode.file_type.is_symlink()
+        } else if child_inode.metadata.is_symlink()
             && (follow == FollowSymlinks::All || !is_last_component)
         {
             // Resolve symlink, unless this is the last component and `follow != All`.
@@ -205,7 +205,7 @@ pub(crate) fn resolve_path(
     // separator. Otherwise, it's an error since non-directories don't
     // have children.
     if path.len() > 1 && path[path.len() - 1] == Path::SEPARATOR {
-        if inode.file_type.is_dir() {
+        if inode.metadata.is_dir() {
             path.pop();
         } else {
             return Err(Ext4Error::NotADirectory);
@@ -367,7 +367,7 @@ mod tests {
         let (dir_inode, path) =
             resolve_path(fs, mkp("/dir1/dir2"), follow).unwrap();
         assert_eq!(path, "/dir1/dir2");
-        assert!(dir_inode.file_type.is_dir());
+        assert!(dir_inode.metadata.is_dir());
 
         // Check directory with trailing separator.
         let (inode, path) =
@@ -422,7 +422,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(path, "/dir1/dir2/sym_abs");
-        assert!(inode.file_type.is_symlink());
+        assert!(inode.metadata.is_symlink());
         let (inode, path) = resolve_path(
             fs,
             mkp("/dir1/dir2/sym_rel"),
@@ -430,7 +430,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(path, "/dir1/dir2/sym_rel");
-        assert!(inode.file_type.is_symlink());
+        assert!(inode.metadata.is_symlink());
 
         // Error: not absolute.
         assert!(matches!(


### PR DESCRIPTION
Instead of having `Metadata` be a thin wrapper around `Inode`, move the metadata fields (mode, file type, and size) from `Inode` to `Metadata`, and add `Metadata` as a field of `Inode`.

The public API is unchanged, this is just a little internal cleanup (and the metadata type is a little smaller now).