### PR TITLE
error: Drop UnresolvedPath error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -296,10 +296,6 @@ pub enum Incompatible {
         /// The algorithm identifier.
         u8,
     ),
-
-    /// A path contains symlink or ".." components, but the operation
-    /// being attempted does not supports this type of path.
-    UnresolvedPath,
 }
 
 impl Display for Incompatible {
@@ -316,9 +312,6 @@ impl Display for Incompatible {
             }
             Self::DirectoryHash(algorithm) => {
                 write!(f, "unsupported directory hash algorithm: {algorithm}")
-            }
-            Self::UnresolvedPath => {
-                write!(f, "path contains a symlink or '..'")
             }
         }
     }


### PR DESCRIPTION
Now that path resolution is properly implemented, nothing produces this error.