### PR TITLE
error: Mark error types as non_exhaustive

### DIFF
--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -18,6 +18,7 @@ use core::str::Utf8Error;
 
 /// Error returned when [`DirEntryName`] construction fails.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum DirEntryNameError {
     /// Name is empty.
     Empty,

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,7 @@ pub trait IoError: Any + Debug + Display + Send + Sync {}
 ///
 /// [`Ext4`]: crate::Ext4
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Ext4Error {
     /// An operation that requires an absolute path was attempted on a
     /// relative path.
@@ -145,6 +146,7 @@ impl std::error::Error for Ext4Error {}
 /// Error type used in [`Ext4Error::Corrupt`] when the filesystem is
 /// corrupt in some way.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Corrupt {
     /// Superblock magic is invalid.
     SuperblockMagic,
@@ -271,6 +273,7 @@ impl Display for Corrupt {
 /// Error type used in [`Ext4Error::Incompatible`] when the filesystem
 /// cannot be read due to incomplete support in this library.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum Incompatible {
     /// One or more unknown bits are set in the incompatible feature flags.
     Unknown(

--- a/src/path.rs
+++ b/src/path.rs
@@ -13,6 +13,7 @@ use core::fmt::{self, Debug, Display, Formatter};
 
 /// Error returned when [`Path`] or [`PathBuf`] construction fails.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum PathError {
     /// Path contains a component longer than 255 bytes.
     ComponentTooLong,


### PR DESCRIPTION
This will allow new error cases to be added in the future without requiring a change to the semver major version.

https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute