### PR TITLE
metadata: Switch Metadata::mode to a u16 and expand docstring

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -45,9 +45,27 @@ impl Metadata {
     }
 
     /// Get the file's UNIX permission bits.
-    pub fn mode(&self) -> u32 {
-        let mode = self.mode.bits() & 0xfff;
-        // Convert from u16 to u32 to match the std `PermissionsExt` interface.
-        u32::from(mode)
+    ///
+    /// Diagram of the returned value's bits:
+    ///
+    /// ```text
+    ///       top four bits are always zero
+    ///       │   
+    ///       │   set uid, set gid, sticky bit
+    ///       │   │  
+    ///       │   │  owner read/write/execute
+    ///       │   │  │  
+    ///       │   │  │  group read/write/execute
+    ///       │   │  │  │  
+    ///       │   │  │  │  other read/write/execute
+    ///       │   │  │  │  │
+    /// (msb) 0000xxxuuugggooo (lsb)
+    /// ```
+    ///
+    /// See `st_mode` in [inode(7)][inode] for more details.
+    ///
+    /// [inode]: https://www.man7.org/linux/man-pages/man7/inode.7.html
+    pub fn mode(&self) -> u16 {
+        self.mode.bits() & 0o7777
     }
 }


### PR DESCRIPTION
This was returning a `u32` to match the `PermissionsExt` interface, but that version of mode is returning the combined node and file type (i.e. the full value of `InodeMode`), so its not an exact match anyway. I think just returning the permission bits is clearer; if we want to match the PermissionsExt interface in the future we should just `impl` that trait.

Also add a diagram of the returned bits and a link to a manpage with more details (covers sticky bit and set uid/gid in particular).