### PR TITLE
Impl Debug for Ext4

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use block_group::BlockGroupDescriptor;
 use core::cell::RefCell;
+use core::fmt::{self, Debug, Formatter};
 use extent::Extents;
 use features::ReadOnlyCompatibleFeatures;
 use inode::{Inode, InodeIndex};
@@ -468,6 +469,18 @@ impl Ext4 {
         }
 
         inner(self, path.try_into().map_err(|_| Ext4Error::MalformedPath)?)
+    }
+}
+
+impl Debug for Ext4 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // Exclude the reader field, which does not impl Debug. Even if
+        // it did, it could be annoying to print out (e.g. if the reader
+        // is a Vec it might contain many megabytes of data).
+        f.debug_struct("Ext4")
+            .field("superblock", &self.superblock)
+            .field("block_group_descriptors", &self.block_group_descriptors)
+            .finish_non_exhaustive()
     }
 }
 

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -14,6 +14,15 @@ fn load_test_disk1() -> Ext4 {
 }
 
 #[test]
+fn test_ext4_debug() {
+    let fs = load_test_disk1();
+    let s = format!("{fs:?}");
+    // Just check the start and end to avoid over-matching on the test data.
+    assert!(s.starts_with("Ext4 { superblock: Superblock { "));
+    assert!(s.ends_with(", .. }"));
+}
+
+#[test]
 fn test_canonicalize() {
     let fs = load_test_disk1();
 


### PR DESCRIPTION
This is mainly useful because it allows calling `unwrap` on a `Result<Ext4, _>` value.