### PR TITLE
xtask: Add diff-walk action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,7 @@ jobs:
           lfs: true
       - uses: Swatinem/rust-cache@v2
       - run: cargo test -p ext4-view -F std
+      - run: cargo xtask diff-walk test_data/test_disk1.bin
 
   doc:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ext4-view",
  "nix",
  "sha2",
  "tempfile",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,10 +12,12 @@ version = "0.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 publish = false
+default-run = "xtask"
 
 [dependencies]
 anyhow = { version = "1.0.86", features = ["backtrace"] }
 clap = { version = "4.5.0", default-features = false, features = ["derive", "help", "std"] }
+ext4-view = { path = "../", features = ["std"] }
 nix = { version = "0.29.0", features = ["user"] }
 sha2 = "0.10.8"
 tempfile = "3.10.1"

--- a/xtask/src/bin/mount_and_walk.rs
+++ b/xtask/src/bin/mount_and_walk.rs
@@ -1,0 +1,113 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! This executable is intended to be run via the `cargo xtask
+//! diff-walk` action, but it can also be run directly:
+//!
+//!     cargo build --release -p xtask --bin mount_and_walk
+//!     sudo target/release/mount_and_walk test_data/test_disk1.bin
+//!
+//! Expects one argument, the path of a file containing an ext4
+//! filesystem.
+//!
+//! Outputs one line for each file in the filesystem (including
+//! directories and symlinks). Each line contains the file's path, mode,
+//! and a summary of the file's contents (e.g. symlink target or a
+//! SHA-256 hash of a regular file's contents). Example:
+//!
+//! ```
+//! /big_dir 755 dir
+//! /big_dir/0 644 file sha256=5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9
+//! ```
+
+use anyhow::{Context, Result};
+use std::io::{self, Write};
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::{env, fs};
+use xtask::diff_walk::{FileContent, WalkDirEntry};
+use xtask::{calc_file_sha256, Mount, ReadOnly};
+
+fn new_dir_entry(dir_entry: fs::DirEntry) -> Result<WalkDirEntry> {
+    let metadata = dir_entry.metadata()?;
+    let path = dir_entry.path();
+
+    // Test for symlink first, because `is_dir` follows symlinks.
+    let content = if metadata.is_symlink() {
+        let target = fs::read_link(&path)?;
+        FileContent::Symlink(target)
+    } else if metadata.is_dir() {
+        FileContent::Dir
+    } else {
+        FileContent::Regular(calc_file_sha256(&path)?)
+    };
+    Ok(WalkDirEntry {
+        path,
+        content,
+        mode: mode_from_metadata(metadata),
+    })
+}
+
+fn mode_from_metadata(metadata: fs::Metadata) -> u16 {
+    // fs::Metadata::mode() returns the full st_mode field which
+    // combines file type and permissions. Mask and truncate to just the
+    // mode bits.
+    let mode = metadata.mode() & 0o7777;
+    u16::try_from(mode).unwrap()
+}
+
+fn walk_mounted(path: &Path) -> Result<Vec<WalkDirEntry>> {
+    assert!(path.is_dir());
+
+    let mut output = Vec::new();
+
+    output.push(WalkDirEntry {
+        path: path.to_path_buf(),
+        content: FileContent::Dir,
+        mode: mode_from_metadata(path.symlink_metadata()?),
+    });
+
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = entry.file_name();
+        if name == "." || name == ".." {
+            continue;
+        }
+        if entry.file_type()?.is_dir() {
+            output.extend(walk_mounted(&path)?);
+        } else {
+            output.push(new_dir_entry(entry)?);
+        }
+    }
+
+    Ok(output)
+}
+
+fn main() -> Result<()> {
+    let path = env::args()
+        .nth(1)
+        .context("missing required path argument")?;
+
+    let mount = Mount::new(Path::new(&path), ReadOnly(true))?;
+    let mut paths = walk_mounted(mount.path())?;
+    paths.sort_unstable();
+
+    for mut dir_entry in paths {
+        // Remove the mount point from the beginning of the path. Append
+        // that to `/` to make the path absolute again. This makes the
+        // output convenient to compare against the library, which
+        // produces absolute paths when iterating over directories.
+        let path = dir_entry.path.strip_prefix(mount.path())?;
+        dir_entry.path = Path::new("/").join(path);
+
+        io::stdout().write_all(&dir_entry.format())?;
+        println!();
+    }
+    Ok(())
+}

--- a/xtask/src/diff_walk.rs
+++ b/xtask/src/diff_walk.rs
@@ -1,0 +1,193 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use anyhow::{bail, Result};
+use ext4_view::Ext4;
+use sha2::{Digest, Sha256};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::{self, Command};
+
+/// Summary of a file's contents.
+///
+/// For regular files this is the SHA256 hash of the file's
+/// contents. For symlinks, the target path. For directories no
+/// additional data is stored.
+#[derive(Eq, PartialEq, Ord, PartialOrd)]
+pub enum FileContent {
+    Dir,
+    /// Symlink target.
+    Symlink(PathBuf),
+    /// SHA256 hash of a regular file's contents.
+    Regular(String),
+}
+
+#[derive(Eq, PartialEq, Ord, PartialOrd)]
+pub struct WalkDirEntry {
+    pub path: PathBuf,
+    pub content: FileContent,
+    pub mode: u16,
+}
+
+impl WalkDirEntry {
+    pub fn format(&self) -> Vec<u8> {
+        let mut output = self.path.as_os_str().as_bytes().to_vec();
+
+        output.push(b' ');
+        output.extend(format!("{:o}", self.mode).as_bytes());
+        output.push(b' ');
+
+        match &self.content {
+            FileContent::Dir => output.extend(b"dir"),
+            FileContent::Symlink(target) => {
+                output.extend(b"symlink=");
+                output.extend(target.as_os_str().as_bytes());
+            }
+            FileContent::Regular(hash) => {
+                output.extend(b"file sha256=");
+                output.extend(hash.as_bytes());
+            }
+        }
+        output
+    }
+}
+
+fn new_dir_entry(
+    fs: &Ext4,
+    dir_entry: ext4_view::DirEntry,
+) -> Result<WalkDirEntry> {
+    let path = dir_entry.path();
+    let metadata = fs.symlink_metadata(&path)?;
+
+    let content = if metadata.is_symlink() {
+        let target = fs.read_link(&path)?;
+        FileContent::Symlink(target.into())
+    } else if metadata.is_dir() {
+        FileContent::Dir
+    } else {
+        let data = fs.read(&path)?;
+        let hash = format!("{:x}", Sha256::digest(data));
+        FileContent::Regular(hash)
+    };
+    Ok(WalkDirEntry {
+        path: dir_entry.path().into(),
+        content,
+        mode: metadata.mode(),
+    })
+}
+
+fn walk_with_lib(
+    fs: &Ext4,
+    path: ext4_view::Path<'_>,
+) -> Result<Vec<WalkDirEntry>> {
+    let mut output = Vec::new();
+
+    output.push(WalkDirEntry {
+        path: ext4_view::PathBuf::from(path).into(),
+        content: FileContent::Dir,
+        mode: fs.symlink_metadata(path)?.mode(),
+    });
+
+    for entry in fs.read_dir(path)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = entry.file_name();
+        if name == "." || name == ".." {
+            continue;
+        }
+
+        // TODO: use DirEntry::file_type once that exists.
+        if fs.symlink_metadata(&path)?.is_dir() {
+            output.extend(walk_with_lib(fs, path.as_path())?);
+        } else {
+            output.push(new_dir_entry(fs, entry)?);
+        }
+    }
+
+    Ok(output)
+}
+
+/// Check that walking the filesystem with the `ext4-view` crate gives
+/// the same results as mounting the filesystem and walking it with
+/// [`std::fs`].
+///
+/// See `./bin/mount_and_walk.rs` for details of mounting and walking
+/// the filesystem. That program is run under `sudo` since `mount`
+/// requires elevated permissions.
+pub fn diff_walk(path: &Path) -> Result<()> {
+    // Build `mount_and_walk` in release mode.
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "--release",
+            "--package",
+            "xtask",
+            "--bin",
+            "mount_and_walk",
+        ])
+        .status()?;
+    if !status.success() {
+        bail!("failed to build mount_and_walk");
+    }
+
+    let actual = {
+        let ext4 = Ext4::load_from_path(path)?;
+        let mut paths = walk_with_lib(&ext4, ext4_view::Path::ROOT)?;
+        paths.sort_unstable();
+        paths
+            .iter()
+            .map(|dir_entry| dir_entry.format())
+            .collect::<Vec<_>>()
+    };
+    let expected = {
+        let output = Command::new("sudo")
+            .arg("target/release/mount_and_walk")
+            .arg(path)
+            .output()?;
+        if !output.status.success() {
+            bail!("mount_and_walk failed: {}", output.status);
+        }
+        let mut lines = output
+            .stdout
+            .split(|c| *c == b'\n')
+            .map(|l| l.to_vec())
+            .collect::<Vec<_>>();
+
+        // Remove the empty line at the end of the file.
+        let last = lines.pop().unwrap();
+        if !last.is_empty() {
+            bail!("unexpected output from mount_and_walk: last line not empty");
+        }
+
+        lines
+    };
+
+    for (a, b) in actual.iter().zip(expected.iter()) {
+        if a != b {
+            println!(
+                "{} != {}",
+                String::from_utf8_lossy(a),
+                String::from_utf8_lossy(b)
+            );
+            process::exit(1);
+        }
+    }
+
+    if actual.len() != expected.len() {
+        println!(
+            "got {} lines, expected {} lines",
+            actual.len(),
+            expected.len()
+        );
+        process::exit(1);
+    }
+
+    println!("success, no differences detected");
+    Ok(())
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -15,6 +15,7 @@ use std::fs::File;
 use std::io;
 use std::path::Path;
 
+pub mod diff_walk;
 pub use mount::{Mount, ReadOnly};
 
 /// Calculate the SHA256 hash of the file at `path`.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,7 +14,7 @@ use std::os::unix::fs::symlink;
 use std::path::PathBuf;
 use std::process::Command;
 use std::{env, str};
-use xtask::{Mount, ReadOnly};
+use xtask::{diff_walk, Mount, ReadOnly};
 
 /// Get the path of the root directory of the repo.
 ///
@@ -234,6 +234,19 @@ enum Action {
     /// The test files will be committed via git-lfs, so developers
     /// working on the repo do not typically need to run this command.
     CreateTestData,
+
+    /// Test that all files/directories in a filesystem are read correctly.
+    ///
+    /// This mounts a filesystem and walks the mount point, then
+    /// compares the result with walking the filesystem via the
+    /// `ext4-view` crate.
+    ///
+    /// Note that mounting a filesystem normally requires elevated
+    /// permissions, so this command runs some code with `sudo`.
+    DiffWalk {
+        /// Path of a file containing an ext4 filesystem.
+        path: PathBuf,
+    },
 }
 
 fn main() -> Result<()> {
@@ -241,5 +254,6 @@ fn main() -> Result<()> {
 
     match &opt.action {
         Action::CreateTestData => create_test_data(),
+        Action::DiffWalk { path } => diff_walk::diff_walk(path),
     }
 }


### PR DESCRIPTION
This provides a very high-level way to test the library. It walks the full filesystem twice: once with the ext4-view library, once by mounting and using normal filesystem operations (this runs under `sudo`). The output is compared to check for any differences.

Also update the CI to run this action on the test disk.