### PR TITLE
cargo: Set list of files to include in the crates.io release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ categories = ["filesystem", "embedded", "no-std"]
 description = "No-std compatible Rust library for reading ext4 filesystems"
 keywords = ["ext4", "filesystem", "no_std"]
 rust-version = "1.73"
+include = [
+    "src/*.rs",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+]
 
 [workspace]
 members = ["xtask"]


### PR DESCRIPTION
The most important effect here is to ensure that the large `test_data` directory will be excluded. In practice this should already be the case because the release CI job does not use LFS, but this ensures that we can't mess it up (e.g. if the default for CI actions changed to download LFS files by default).
    
Various other files and directories (e.g. `.github` and `tests`) will be excluded as well, they aren't needed when building `ext4-view` as a dependency.