### PR TITLE
path: Impl addition Path/PathBuf conversions

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -8,6 +8,7 @@
 
 use crate::dir_entry::{DirEntryName, DirEntryNameError};
 use crate::format::{format_bytes_debug, BytesDisplay};
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug, Display, Formatter};
 
@@ -130,6 +131,14 @@ impl<'a> TryFrom<&'a str> for Path<'a> {
     type Error = PathError;
 
     fn try_from(s: &'a str) -> Result<Self, PathError> {
+        Self::try_from(s.as_bytes())
+    }
+}
+
+impl<'a> TryFrom<&'a String> for Path<'a> {
+    type Error = PathError;
+
+    fn try_from(s: &'a String) -> Result<Self, PathError> {
         Self::try_from(s.as_bytes())
     }
 }
@@ -318,6 +327,22 @@ impl TryFrom<&str> for PathBuf {
 
     fn try_from(s: &str) -> Result<Self, PathError> {
         Self::try_from(s.as_bytes().to_vec())
+    }
+}
+
+impl TryFrom<&String> for PathBuf {
+    type Error = PathError;
+
+    fn try_from(s: &String) -> Result<Self, PathError> {
+        Self::try_from(s.as_bytes().to_vec())
+    }
+}
+
+impl TryFrom<String> for PathBuf {
+    type Error = PathError;
+
+    fn try_from(s: String) -> Result<Self, PathError> {
+        Self::try_from(s.into_bytes())
     }
 }
 

--- a/tests/integration/path.rs
+++ b/tests/integration/path.rs
@@ -12,8 +12,15 @@ use ext4_view::{Component, Path, PathBuf, PathError};
 fn test_path_construction() {
     let expected_path = b"abc";
 
-    // Successful construction from a string.
+    // Successful construction from a `&str`.
     let src: &str = "abc";
+    assert_eq!(Path::try_from(src).unwrap(), expected_path);
+    assert_eq!(Path::new(src), expected_path);
+    assert_eq!(PathBuf::try_from(src).unwrap(), expected_path);
+    assert_eq!(PathBuf::new(src), expected_path);
+
+    // Successful construction from a `&String`.
+    let src: &String = &"abc".to_owned();
     assert_eq!(Path::try_from(src).unwrap(), expected_path);
     assert_eq!(Path::new(src), expected_path);
     assert_eq!(PathBuf::try_from(src).unwrap(), expected_path);
@@ -35,6 +42,10 @@ fn test_path_construction() {
 
     // Successful construction from a vector (only for PathBuf).
     let src: Vec<u8> = b"abc".to_vec();
+    assert_eq!(PathBuf::try_from(src).unwrap(), expected_path);
+
+    // Successful construction from a `String` (only for PathBuf).
+    let src: String = "abc".to_owned();
     assert_eq!(PathBuf::try_from(src).unwrap(), expected_path);
 
     // Successful construction of a `Path` from a `&PathBuf`.


### PR DESCRIPTION
Path and PathBuf can now be created with try_from from `&String`, and PathBuf can be created from a `String`.