### PR TITLE
inode: Add DIRECTORY_ENCRYPTED flag

### DIFF
--- a/src/inode.rs
+++ b/src/inode.rs
@@ -31,6 +31,9 @@ bitflags! {
         /// File is immutable.
         const IMMUTABLE = 0x10;
 
+        /// Directory is encrypted.
+        const DIRECTORY_ENCRYPTED = 0x800;
+
         /// Directory has hashed indexes.
         const DIRECTORY_HTREE = 0x1000;
 


### PR DESCRIPTION
Not actually used for anything yet, but this will be used to check if a directory is encrypted before trying to read it.