### PR TITLE
xtask: Add basic support for encrypted dirs in diff-walk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "clap",
  "ext4-view",
  "gpt_disk_io",
+ "libc",
  "lzma-rs",
  "nix",
  "sha2",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = { version = "1.0.86", features = ["backtrace"] }
 clap = { version = "4.5.0", default-features = false, features = ["derive", "help", "std"] }
 ext4-view = { path = "../", features = ["std"] }
 gpt_disk_io = { version = "0.16.0", features = ["std"] }
+libc = "0.2.155"
 lzma-rs = "0.3.0"
 nix = { version = "0.29.0", features = ["user"] }
 sha2 = "0.10.8"

--- a/xtask/src/diff_walk.rs
+++ b/xtask/src/diff_walk.rs
@@ -21,7 +21,10 @@ use std::process::{self, Command};
 /// additional data is stored.
 #[derive(Eq, PartialEq, Ord, PartialOrd)]
 pub enum FileContent {
+    /// Regular directory.
     Dir,
+    /// Encrypted directory.
+    EncryptedDir,
     /// Symlink target.
     Symlink(PathBuf),
     /// SHA256 hash of a regular file's contents.
@@ -45,6 +48,7 @@ impl WalkDirEntry {
 
         match &self.content {
             FileContent::Dir => output.extend(b"dir"),
+            FileContent::EncryptedDir => output.extend(b"dir encrypted"),
             FileContent::Symlink(target) => {
                 output.extend(b"symlink=");
                 output.extend(target.as_os_str().as_bytes());


### PR DESCRIPTION
In `mount_and_walk` (which is the version of diff-walk that mounts the filesystem rather than using ext4-view), encrypted directories will now be handled by marking them as "dir encrypted". The walk will not descend into the encrypted directory's contents.

The diff-walk that uses ext4-view will also be updated to have the same behavior in a future commit.