### PR TITLE
Add better handling for encrypted directories

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -299,6 +299,13 @@ pub enum Incompatible {
         /// The algorithm identifier.
         u8,
     ),
+
+    /// Attempted to read an encrypted directory. Only unencrypted
+    /// directories are currently supported.
+    DirectoryEncrypted(
+        /// Inode number.
+        u32,
+    ),
 }
 
 impl Display for Incompatible {
@@ -315,6 +322,9 @@ impl Display for Incompatible {
             }
             Self::DirectoryHash(algorithm) => {
                 write!(f, "unsupported directory hash algorithm: {algorithm}")
+            }
+            Self::DirectoryEncrypted(inode) => {
+                write!(f, "directory in inode {inode} is encrypted")
             }
         }
     }

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -149,8 +149,7 @@ fn check_incompat_features(
         | IncompatibleFeatures::LARGE_EXTENDED_ATTRIBUTES_IN_INODES
         | IncompatibleFeatures::DATA_IN_DIR_ENTRY
         | IncompatibleFeatures::LARGE_DIRECTORIES
-        | IncompatibleFeatures::DATA_IN_INODE
-        | IncompatibleFeatures::ENCRYPTED_INODES;
+        | IncompatibleFeatures::DATA_IN_INODE;
 
     let present_required = actual & required_features;
     if present_required != required_features {


### PR DESCRIPTION
Ext4 allows for individual directories to be encrypted. This library doesn't have support for encrypted directories yet, but we can at least provide a better error when one is encountered. Rather than returning a "DirEntry corrupt" error, add a new `Incompatible::DirectoryEncrypted` error.

This error is used in two places: when creating a ReadDir iter, and when looking up a directory entry.

Also remove `ENCRYPTED_INODES` from the list of disallowed features.