### PR TITLE
ci: Add test job that runs on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,15 @@ jobs:
       - run: cargo test -p ext4-view -F std
       - run: cargo xtask diff-walk test_data/test_disk1.bin
 
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test -p ext4-view -F std
+
   doc:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This should help catch some platform-specific mistakes like forgetting a `cfg(unix)`.