### PR TITLE
Add dir_entry::file_type method

### DIFF
--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -37,6 +37,19 @@ pub enum FileType {
 }
 
 impl FileType {
+    pub(crate) fn from_dir_entry(val: u8) -> Result<Self, FileTypeError> {
+        match val {
+            1 => Ok(Self::Regular),
+            2 => Ok(Self::Directory),
+            3 => Ok(Self::CharacterDevice),
+            4 => Ok(Self::BlockDevice),
+            5 => Ok(Self::Fifo),
+            6 => Ok(Self::Socket),
+            7 => Ok(Self::Symlink),
+            _ => Err(FileTypeError),
+        }
+    }
+
     /// Returns true if the file is a block device.
     pub fn is_block_dev(self) -> bool {
         self == FileType::BlockDevice

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -238,6 +238,17 @@ fn test_read_dir() {
     let mut entry_paths: Vec<PathBuf> = dir.iter().map(|e| e.path()).collect();
     entry_paths.sort_unstable();
 
+    // Check file types.
+    for entry in &dir {
+        let fname = entry.file_name();
+        let ftype = entry.file_type().unwrap();
+        if fname == "." || fname == ".." {
+            assert!(ftype.is_dir());
+        } else {
+            assert!(ftype.is_regular_file());
+        }
+    }
+
     // Get expected entry names, 0-9999.
     let mut expected_names = vec![".".to_owned(), "..".to_owned()];
     expected_names.extend((0u32..10_000u32).map(|n| n.to_string()));

--- a/xtask/src/diff_walk.rs
+++ b/xtask/src/diff_walk.rs
@@ -116,8 +116,7 @@ fn walk_with_lib(
             continue;
         }
 
-        // TODO: use DirEntry::file_type once that exists.
-        if fs.symlink_metadata(&path)?.is_dir() {
+        if entry.file_type()?.is_dir() {
             output.extend(walk_with_lib(fs, path.as_path())?);
         } else {
             output.push(new_dir_entry(fs, entry)?);


### PR DESCRIPTION
The file type is encoded in the directory entry. This is faster than calling the metadata function since no extra path traversal or inode reads are needed.

Also update diff-walk to use the new method.