### PR TITLE
xtask: Add helpers for running commands

### DIFF
--- a/xtask/src/diff_walk.rs
+++ b/xtask/src/diff_walk.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::capture_cmd;
 use anyhow::{bail, Result};
 use ext4_view::{Ext4, Ext4Error, Incompatible};
 use sha2::{Digest, Sha256};
@@ -174,13 +175,11 @@ pub fn diff_walk(path: &Path) -> Result<()> {
     };
     let expected = {
         let before_cmd = SystemTime::now();
-        let output = Command::new("sudo")
-            .arg("target/release/mount_and_walk")
-            .arg(path)
-            .output()?;
-        if !output.status.success() {
-            bail!("mount_and_walk failed: {}", output.status);
-        }
+        let output = capture_cmd(
+            Command::new("sudo")
+                .arg("target/release/mount_and_walk")
+                .arg(path),
+        )?;
         println!(
             "mount_and_walk took {:?}",
             SystemTime::now().duration_since(before_cmd).unwrap()

--- a/xtask/src/mount.rs
+++ b/xtask/src/mount.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use anyhow::{bail, Result};
+use crate::run_cmd;
+use anyhow::Result;
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
@@ -27,13 +28,11 @@ impl Mount {
     /// Mounting is a privileged operation, so this runs `sudo mount`.
     pub fn new(fs_bin: &Path, read_only: ReadOnly) -> Result<Self> {
         let mount_point = TempDir::new()?;
-        let status = Command::new("sudo")
-            .args(["mount", "-o", if read_only.0 { "ro" } else { "rw" }])
-            .args([fs_bin, mount_point.path()])
-            .status()?;
-        if !status.success() {
-            bail!("mount failed");
-        }
+        run_cmd(
+            Command::new("sudo")
+                .args(["mount", "-o", if read_only.0 { "ro" } else { "rw" }])
+                .args([fs_bin, mount_point.path()]),
+        )?;
         Ok(Self { mount_point })
     }
 


### PR DESCRIPTION
The helpers take care of providing good error messages and also ensure that the exit status is checked, which is easy to forget.