### PR TITLE
Drop requirement for extents and 64-bit feature flags

### DIFF
--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -142,12 +142,9 @@ fn check_incompat_features(
         return Err(Incompatible::Unknown(actual.difference(actual_known)));
     }
 
-    // TODO: for now, be strict on most incompat features. May be able to
+    // TODO: for now, be strict on many incompat features. May be able to
     // relax some of these in the future.
-    let required_features = IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY
-        | IncompatibleFeatures::EXTENTS
-        | IncompatibleFeatures::IS_64BIT
-        | IncompatibleFeatures::FLEXIBLE_BLOCK_GROUPS;
+    let required_features = IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY;
     let disallowed_features = IncompatibleFeatures::COMPRESSION
         | IncompatibleFeatures::RECOVERY
         | IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE
@@ -300,8 +297,6 @@ mod tests {
     #[test]
     fn test_check_incompat_features() {
         let required = (IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY
-            | IncompatibleFeatures::EXTENTS
-            | IncompatibleFeatures::IS_64BIT
             | IncompatibleFeatures::FLEXIBLE_BLOCK_GROUPS
             | IncompatibleFeatures::CHECKSUM_SEED_IN_SUPERBLOCK)
             .bits();
@@ -319,10 +314,11 @@ mod tests {
 
         assert_eq!(
             check_incompat_features(
-                required & (!IncompatibleFeatures::IS_64BIT.bits())
+                required
+                    & (!IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY.bits())
             )
             .unwrap_err(),
-            Incompatible::Missing(IncompatibleFeatures::IS_64BIT)
+            Incompatible::Missing(IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY)
         );
 
         assert_eq!(

--- a/tests/integration/ext2.rs
+++ b/tests/integration/ext2.rs
@@ -1,0 +1,50 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use ext4_view::Ext4;
+
+fn load_ext2() -> Ext4 {
+    let output = std::process::Command::new("zstd")
+        .args([
+            "--decompress",
+            // Write to stdout and don't delete the input file.
+            "--stdout",
+            "test_data/test_disk_ext2.bin.zst",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    Ext4::load(Box::new(output.stdout)).unwrap()
+}
+
+// This function is duplicated in `/xtask/src/main.rs`.
+fn gen_big_file(num_blocks: u32) -> Vec<u8> {
+    let mut file = Vec::new();
+    let block_size = 1024;
+    for i in 0..num_blocks {
+        let mut block = vec![0; block_size];
+        let i_le = i.to_le_bytes();
+        block[..4].copy_from_slice(&i_le);
+        block[block_size - 4..].copy_from_slice(&i_le);
+        file.extend(block);
+    }
+    file
+}
+
+#[test]
+fn test_read_small_file() {
+    let fs = load_ext2();
+    assert_eq!(fs.read("/small_file").unwrap(), b"hello, world!");
+}
+
+#[test]
+fn test_read_big_file() {
+    let fs = load_ext2();
+    let num_blocks = 12 + 256 + (256 * 256) + (256 * 16);
+    assert_eq!(fs.read("/big_file").unwrap(), gen_big_file(num_blocks));
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -6,5 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+mod ext2;
 mod ext4;
 mod path;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -44,6 +44,8 @@ fn test_data_dir() -> Result<PathBuf> {
 /// 1024. Each block will be all zeroes, except for the first and last
 /// four bytes, which will contain the block index encoded as a
 /// little-endian `u32`.
+///
+/// This function is duplicated in `/tests/integration/ext2.rs`.
 fn gen_big_file(num_blocks: u32) -> Vec<u8> {
     let mut file = Vec::new();
     let block_size = 1024;


### PR DESCRIPTION
This allows ext2 filesystems to be loaded.