### PR TITLE
wip: Make Ext4 struct cheap to clone

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -152,6 +152,7 @@ impl ReadDir {
         }
 
         let (entry, entry_size) = DirEntry::from_bytes(
+            self.fs.clone(),
             &self.block[self.offset_within_block..],
             self.inode,
             self.path.clone(),

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -338,6 +338,29 @@ fn test_metadata_uid_gid() {
 }
 
 #[test]
+fn test_direntry_metadata() {
+    let fs = load_test_disk1();
+
+    let entry = fs
+        .read_dir("/")
+        .unwrap()
+        .find_map(|entry| {
+            let entry = entry.unwrap();
+            if entry.file_name() == "small_file" {
+                Some(entry)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    let metadata = entry.metadata().unwrap();
+    assert_eq!(
+        metadata.len(),
+        u64::try_from("hello, world!".len()).unwrap()
+    );
+}
+
+#[test]
 fn test_symlink_metadata() {
     let fs = load_test_disk1();
 

--- a/xtask/src/diff_walk.rs
+++ b/xtask/src/diff_walk.rs
@@ -73,7 +73,7 @@ fn new_dir_entry(
     dir_entry: ext4_view::DirEntry,
 ) -> Result<WalkDirEntry> {
     let path = dir_entry.path();
-    let metadata = fs.symlink_metadata(&path)?;
+    let metadata = dir_entry.metadata()?;
 
     let content = if metadata.is_symlink() {
         let target = fs.read_link(&path)?;


### PR DESCRIPTION
This will make the design more similar to the implementation of `std::fs`. Structs like `ReadDir` that currently have a lifetime param won't need one anymore (because they'll be able to cheaply store an `Ext4` rather than an `&Ext4` reference). `DirEntry`, which doesn't currently store an `Ext4` reference, will be able to add a `metadata` method, which is more efficient than passing the direntry path to `Ext4::metadata()`.