### PR TITLE
block_group: Add BlockGroupDescriptor::read_all

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,21 +177,14 @@ impl Ext4 {
 
         let superblock = Superblock::from_bytes(&data)?;
 
-        let mut ext4 = Self {
+        Ok(Self {
+            block_group_descriptors: BlockGroupDescriptor::read_all(
+                &superblock,
+                &mut *reader,
+            )?,
             reader: RefCell::new(reader),
-            block_group_descriptors: Vec::with_capacity(usize_from_u32(
-                superblock.num_block_groups,
-            )),
             superblock,
-        };
-
-        // Read all the block group descriptors.
-        for bgd_index in 0..ext4.superblock.num_block_groups {
-            let bgd = BlockGroupDescriptor::read(&ext4, bgd_index)?;
-            ext4.block_group_descriptors.push(bgd);
-        }
-
-        Ok(ext4)
+        })
     }
 
     /// Load an `Ext4` filesystem from the given `path`.


### PR DESCRIPTION
Before this commit, BlockGroupDescriptor::read took an `&Ext4` arg. This made the code a little unclear because the `Ext4` struct was not fully initialized at that point.

Refactor the code so that reading the block group descriptors occurs entirely in the block_group module. Add BlockGroupDescriptor::read_all, which takes the superblock and reader as args rather than an `&Ext4`.