### PR TITLE
Make the Ext4 struct cheap to clone

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -84,7 +84,7 @@ impl<'a> ReadDir<'a> {
             extents: Extents::new(fs, inode)?,
             extent: None,
             block_index: 0,
-            block: vec![0; usize_from_u32(fs.superblock.block_size)],
+            block: vec![0; usize_from_u32(fs.0.superblock.block_size)],
             offset_within_block: 0,
             is_done: false,
             has_htree,
@@ -131,7 +131,7 @@ impl<'a> ReadDir<'a> {
 
         // If a block has been fully processed, move to the next block
         // on the next iteration.
-        let block_size = self.fs.superblock.block_size;
+        let block_size = self.fs.0.superblock.block_size;
         if self.offset_within_block >= usize_from_u32(block_size) {
             self.block_index += 1;
             self.offset_within_block = 0;

--- a/src/dir_block.rs
+++ b/src/dir_block.rs
@@ -53,7 +53,7 @@ impl<'a> DirBlock<'a> {
     /// If checksums are enabled for the filesystem, the directory
     /// block's checksum will be verified.
     pub(crate) fn read(&self, block: &mut [u8]) -> Result<(), Ext4Error> {
-        let block_size = self.fs.superblock.block_size;
+        let block_size = self.fs.0.superblock.block_size;
         assert_eq!(block.len(), usize_from_u32(block_size));
 
         let block_index = self.extent.start_block + self.block_within_extent;
@@ -138,7 +138,7 @@ impl<'a> DirBlock<'a> {
         // Other internal nodes are identified by the first record
         // having a length equal to the whole block.
         let first_rec_len = u32::from(read_u16le(block, 4));
-        if first_rec_len == self.fs.superblock.block_size {
+        if first_rec_len == self.fs.0.superblock.block_size {
             DirBlockType::Internal
         } else {
             DirBlockType::Leaf

--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -256,7 +256,7 @@ fn find_leaf_node(
     // Get the node structure from the root block.
     let root_node = InternalNode::from_root_block(block, inode.index)?;
 
-    let hash = dir_hash_md4_half(name, &fs.superblock.htree_hash_seed);
+    let hash = dir_hash_md4_half(name, &fs.0.superblock.htree_hash_seed);
     let mut child_block_relative = root_node.lookup_block_by_hash(hash);
 
     // Descend through the tree one level at a time. The first iteration
@@ -307,7 +307,7 @@ pub(crate) fn get_dir_entry_via_htree(
 ) -> Result<DirEntry, Ext4Error> {
     assert!(inode.flags.contains(InodeFlags::DIRECTORY_HTREE));
 
-    let block_size = fs.superblock.block_size;
+    let block_size = fs.0.superblock.block_size;
     let mut block = vec![0; usize_from_u32(block_size)];
 
     // Read the first block of the file, which contains the root node of
@@ -419,7 +419,7 @@ mod tests {
         let fs_path = std::path::Path::new("test_data/test_disk1.bin");
         let fs = Ext4::load_from_path(fs_path).unwrap();
 
-        let mut block = vec![0; usize_from_u32(fs.superblock.block_size)];
+        let mut block = vec![0; usize_from_u32(fs.0.superblock.block_size)];
 
         // Read the root block of an htree.
         let inode = fs

--- a/src/extent.rs
+++ b/src/extent.rs
@@ -216,7 +216,7 @@ impl<'a> Extents<'a> {
             // find out how much data is in the full child node.
             let mut child_header = [0; ENTRY_SIZE_IN_BYTES];
             let child_start =
-                child_block * u64::from(self.ext4.superblock.block_size);
+                child_block * u64::from(self.ext4.0.superblock.block_size);
             self.ext4.read_bytes(child_start, &mut child_header)?;
             let child_header =
                 NodeHeader::from_bytes(&child_header, self.inode)?;

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -149,7 +149,7 @@ impl Inode {
         let mode = InodeMode::from_bits_retain(i_mode);
 
         let mut checksum_base =
-            Checksum::with_seed(ext4.superblock.checksum_seed);
+            Checksum::with_seed(ext4.0.superblock.checksum_seed);
         checksum_base.update_u32_le(index.get());
         checksum_base.update_u32_le(i_generation);
 
@@ -179,11 +179,12 @@ impl Inode {
         ext4: &Ext4,
         inode: InodeIndex,
     ) -> Result<Inode, Ext4Error> {
-        let sb = &ext4.superblock;
+        let sb = &ext4.0.superblock;
 
         let block_group_index = (inode.get() - 1) / sb.inodes_per_block_group;
 
         let group = ext4
+            .0
             .block_group_descriptors
             .get(usize_from_u32(block_group_index))
             .ok_or(Ext4Error::Corrupt(Corrupt::Inode(inode.get())))?;


### PR DESCRIPTION
The internal fields of Ext4 are now in a new `Ext4Inner` struct, which Ext4 stores in an `Rc` (think `shared_ptr` in C++ terms, but single-threaded).

This will allow Ext4 to be cheaply passed around by cloning it rather than with a reference, which in turn means that other structs can access the filesystem without having a lifetime parameter. That will (in future commits) make it possible to drop the lifetime param from `ReadDir`, and to add more functionality to `DirEntry` without adding a lifetime param.