### PR TITLE
Drop lifetime from the Extents struct

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -33,7 +33,7 @@ pub struct ReadDir<'a> {
     path: Rc<PathBuf>,
 
     /// Iterator over the directory's extents.
-    extents: Extents<'a>,
+    extents: Extents,
 
     /// The current extent.
     extent: Option<Extent>,
@@ -81,7 +81,7 @@ impl<'a> ReadDir<'a> {
         Ok(Self {
             fs,
             path: Rc::new(path),
-            extents: Extents::new(fs, inode)?,
+            extents: Extents::new(fs.clone(), inode)?,
             extent: None,
             block_index: 0,
             block: vec![0; usize_from_u32(fs.0.superblock.block_size)],

--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -155,7 +155,7 @@ fn read_root_block(
     inode: &Inode,
     block: &mut [u8],
 ) -> Result<(), Ext4Error> {
-    let mut extents = Extents::new(fs, inode)?;
+    let mut extents = Extents::new(fs.clone(), inode)?;
 
     // Get the first extent.
     let extent = extents.next().ok_or_else(|| {
@@ -215,7 +215,7 @@ fn find_extent_for_block(
     inode: &Inode,
     block: ChildBlock,
 ) -> Result<Extent, Ext4Error> {
-    for extent in Extents::new(fs, inode)? {
+    for extent in Extents::new(fs.clone(), inode)? {
         let extent = extent?;
 
         let start = extent.block_within_file;

--- a/src/extent.rs
+++ b/src/extent.rs
@@ -137,18 +137,15 @@ impl ToVisitItem {
 }
 
 /// Iterator of an inode's extent tree.
-pub(crate) struct Extents<'a> {
-    ext4: &'a Ext4,
+pub(crate) struct Extents {
+    ext4: Ext4,
     inode: InodeIndex,
     to_visit: Vec<ToVisitItem>,
     checksum_base: Checksum,
 }
 
-impl<'a> Extents<'a> {
-    pub(crate) fn new(
-        ext4: &'a Ext4,
-        inode: &Inode,
-    ) -> Result<Self, Ext4Error> {
+impl Extents {
+    pub(crate) fn new(ext4: Ext4, inode: &Inode) -> Result<Self, Ext4Error> {
         Ok(Self {
             ext4,
             inode: inode.index,
@@ -260,7 +257,7 @@ impl<'a> Extents<'a> {
     }
 }
 
-impl<'a> Iterator for Extents<'a> {
+impl Iterator for Extents {
     type Item = Result<Extent, Ext4Error>;
 
     fn next(&mut self) -> Option<Result<Extent, Ext4Error>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ impl Ext4 {
             .map_err(|_| Ext4Error::FileTooLarge)?;
         let mut dst = vec![0; file_size_in_bytes];
 
-        for extent in Extents::new(self, inode)? {
+        for extent in Extents::new(self.clone(), inode)? {
             let extent = extent?;
 
             let dst_start =


### PR DESCRIPTION
Now that the filesystem can be cheaply cloned, a reference is not needed.