### PR TITLE
Add DirEntry::metadata method

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -152,6 +152,7 @@ impl ReadDir {
         }
 
         let (entry, entry_size) = DirEntry::from_bytes(
+            self.fs.clone(),
             &self.block[self.offset_within_block..],
             self.inode,
             self.path.clone(),

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -338,6 +338,29 @@ fn test_metadata_uid_gid() {
 }
 
 #[test]
+fn test_direntry_metadata() {
+    let fs = load_test_disk1();
+
+    let entry = fs
+        .read_dir("/")
+        .unwrap()
+        .find_map(|entry| {
+            let entry = entry.unwrap();
+            if entry.file_name() == "small_file" {
+                Some(entry)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    let metadata = entry.metadata().unwrap();
+    assert_eq!(
+        metadata.len(),
+        u64::try_from("hello, world!".len()).unwrap()
+    );
+}
+
+#[test]
 fn test_symlink_metadata() {
     let fs = load_test_disk1();
 


### PR DESCRIPTION
This is essentially the same as doing `fs.symlink_metadata(dir_entry.path())`, but more efficient because the inode is already known.