### PR TITLE
Add FileBlocks iterator and use it in directory iteration/lookup

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -143,8 +143,8 @@ impl ReadDir {
             DirBlock {
                 fs: &self.fs,
                 dir_inode: self.inode,
-                extent,
-                block_within_extent: self.block_index,
+                block_index: extent.start_block + self.block_index,
+                is_first: self.block_index == 0,
                 has_htree: self.has_htree,
                 checksum_base: self.checksum_base.clone(),
             }

--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -166,8 +166,8 @@ fn read_root_block(
     let dir_block = DirBlock {
         fs,
         dir_inode: inode.index,
-        extent: &extent,
-        block_within_extent: 0,
+        block_index: extent.start_block,
+        is_first: true,
         has_htree: true,
         checksum_base: inode.checksum_base.clone(),
     };
@@ -271,10 +271,8 @@ fn find_leaf_node(
         let dir_block = DirBlock {
             fs,
             dir_inode: inode.index,
-            extent: &extent,
-            block_within_extent: u64::from(
-                child_block_relative - extent.block_within_file,
-            ),
+            block_index: extent.start_block + u64::from(child_block_relative),
+            is_first: false,
             has_htree: true,
             checksum_base: inode.checksum_base.clone(),
         };

--- a/src/file_blocks.rs
+++ b/src/file_blocks.rs
@@ -1,0 +1,117 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// TODO: temporarily allow dead code to keep the commit smaller.
+#![allow(dead_code)]
+
+use crate::extent::{Extent, Extents};
+use crate::inode::Inode;
+use crate::{Ext4, Ext4Error};
+
+/// Iterator over blocks in a file that uses extents.
+///
+/// The iterator produces absolute block indices. Note that no blocks
+/// are produced for holes in the file (i.e. parts of the file not
+/// covered by an extent).
+pub(crate) struct ExtentsBlocks {
+    /// Extent iterator.
+    extents: Extents,
+
+    /// Current extent, or `None` if a new extent needs to be fetched
+    /// from the iterator.
+    extent: Option<Extent>,
+
+    /// Current block index within the extent.
+    block_within_extent: u16,
+
+    /// Whether the iterator is done (all calls to `next` will return `None`).
+    is_done: bool,
+}
+
+impl ExtentsBlocks {
+    pub(crate) fn new(fs: Ext4, inode: &Inode) -> Result<Self, Ext4Error> {
+        Ok(Self {
+            extents: Extents::new(fs, inode)?,
+            extent: None,
+            block_within_extent: 0,
+            is_done: false,
+        })
+    }
+
+    fn next_impl(&mut self) -> Result<Option<u64>, Ext4Error> {
+        // Get the extent, or get the next one if not set.
+        let extent = if let Some(extent) = &self.extent {
+            extent
+        } else {
+            match self.extents.next() {
+                Some(Ok(extent)) => {
+                    self.extent = Some(extent);
+                    self.block_within_extent = 0;
+
+                    // OK to unwrap since we just set it.
+                    self.extent.as_ref().unwrap()
+                }
+                Some(Err(err)) => return Err(err),
+                None => {
+                    self.is_done = true;
+                    return Ok(None);
+                }
+            }
+        };
+
+        // If all blocks in the extent have been processed, move to the
+        // next extent on the next iteration.
+        if self.block_within_extent == extent.num_blocks {
+            self.extent = None;
+            return Ok(None);
+        }
+
+        let block = extent.start_block + u64::from(self.block_within_extent);
+
+        self.block_within_extent += 1;
+
+        Ok(Some(block))
+    }
+}
+
+impl Iterator for ExtentsBlocks {
+    /// Absolute block index.
+    type Item = Result<u64, Ext4Error>;
+
+    fn next(&mut self) -> Option<Result<u64, Ext4Error>> {
+        // In pseudocode, here's what the iterator is doing:
+        //
+        // for extent in extents(inode) {
+        //   for block in extent.blocks {
+        //     yield block;
+        //   }
+        // }
+
+        loop {
+            if self.is_done {
+                return None;
+            }
+
+            match self.next_impl() {
+                Ok(Some(entry)) => return Some(Ok(entry)),
+                Ok(None) => {
+                    // Continue.
+                }
+                Err(err) => {
+                    self.is_done = true;
+                    return Some(Err(err));
+                }
+            }
+        }
+    }
+}
+
+// TODO: when support for files that use block maps instead of extents
+// is added, this type alias will become an enum that supports both
+// kinds of iteration.
+pub(crate) type FileBlocks = ExtentsBlocks;

--- a/src/file_blocks.rs
+++ b/src/file_blocks.rs
@@ -6,9 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// TODO: temporarily allow dead code to keep the commit smaller.
-#![allow(dead_code)]
-
 use crate::extent::{Extent, Extents};
 use crate::inode::Inode;
 use crate::{Ext4, Ext4Error};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ mod dir_htree;
 mod error;
 mod extent;
 mod features;
+mod file_blocks;
 mod file_type;
 mod format;
 mod inode;


### PR DESCRIPTION
This simplifies the `ReadDir` iterator slightly. The larger purpose of this iterator is to provide an abstraction that can be used for block maps in addition to extents. Block maps are how file blocks were stored prior to extents.