### PR TITLE
ci: Combine test jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,17 +55,19 @@ jobs:
         with:
           lfs: true
       - uses: Swatinem/rust-cache@v2
+      # Test with no features enabled.
       - run: cargo test -p ext4-view
-
-  test-std:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo test -p ext4-view -F std
+      # Test diff-walk.
       - run: cargo xtask diff-walk test_data/test_disk1.bin
+      # Test with std enabled, and upload coverage results.
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov -F std --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
 
   test-windows:
     runs-on: windows-latest
@@ -104,19 +106,3 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: crate-ci/typos@v1.24.3
-
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      - uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo llvm-cov -F std --lcov --output-path lcov.info
-      - uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: lcov.info
-          fail_ci_if_error: true


### PR DESCRIPTION
Combine the test, test-std, and coverage jobs into one. This reduces the number of jobs that require LFS files from 4 to 2 (one Linux job, one Windows job), which will help some with Github's LFS bandwidth cap.