### PR TITLE
renovate: Switch to 'replace' strategy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "rangeStrategy": "replace",
   "lockFileMaintenance": {
     "enabled": true
   }


### PR DESCRIPTION
This should cause renovate to only open PRs for Rust dep changes when they affect Cargo.toml, except for lockFileMaintenance, which will continue to update pinned dependencies in Cargo.lock.

The behavior of this strategy was broken for a while (it was incorrectly changing Cargo.toml even when not necessary), and I'm not sure if it's been fixed. Let's give it a try and see what happens.