### PR TITLE
renovate: Switch to 'update-lockfile' strategy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "rangeStrategy": "replace",
+  "rangeStrategy": "update-lockfile",
   "lockFileMaintenance": {
     "enabled": true
   }


### PR DESCRIPTION
The 'replace' strategy is still incorrectly modifying Cargo.toml when it shouldn't. See https://github.com/renovatebot/renovate/issues/19809