### PR TITLE
renovate: Only update typos package once a month

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,11 @@
   "rangeStrategy": "update-lockfile",
   "lockFileMaintenance": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": ["crate-ci/typos"],
+      "extends": ["schedule:monthly"]
+    }
+  ]
 }


### PR DESCRIPTION
This package gets fairly frequent releases, but there's nothing critical about them.