### PR TITLE
renovate: Enable automerge after review

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended"
   ],
   "rangeStrategy": "update-lockfile",
+  "automerge": true,
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
Despite the name, this setting won't actually automerge renovate PRs. It just enables merging once all requirements are met. Due to branch protection rules, all PRs to the `main` branch require a reviewer to approve before they can be merged. Enabling this will just save the reviewer a few clicks for renovate PRs.