### PR TITLE
Fix descriptor size if the 64-bit feature flag is not set

### DIFF
--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -89,6 +89,13 @@ impl Superblock {
         )
         .map_err(|_| Ext4Error::Corrupt(Corrupt::TooManyBlockGroups))?;
 
+        let block_group_descriptor_size =
+            if incompatible_features.contains(IncompatibleFeatures::IS_64BIT) {
+                s_desc_size
+            } else {
+                32
+            };
+
         // Validate the superblock checksum.
         if read_only_compatible_features
             .contains(ReadOnlyCompatibleFeatures::METADATA_CHECKSUMS)
@@ -115,7 +122,7 @@ impl Superblock {
             blocks_count,
             inode_size: s_inode_size,
             inodes_per_block_group: s_inodes_per_group,
-            block_group_descriptor_size: s_desc_size,
+            block_group_descriptor_size,
             num_block_groups,
             incompatible_features,
             read_only_compatible_features,


### PR DESCRIPTION
The descriptor size field of the superblock is only used if the 64-bit feature flag is set, otherwise the size is always 32.

This code isn't actually reachable yet (the incompatible feature flag check happens first), so no test yet.