### PR TITLE
Fix reading ext2 files with holes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,12 @@ impl Ext4 {
                 let dst = &mut dst[dst_start..dst_end];
                 dst_start += usize_from_u32(block_size);
 
-                self.read_bytes(src_start, dst)?;
+                // If the block index is zero, it's a hole, which should
+                // be filled with zeroes. The destination is already
+                // zeroed, so nothing to do in that case.
+                if block_index != 0 {
+                    self.read_bytes(src_start, dst)?;
+                }
             }
         }
         Ok(dst)

--- a/tests/integration/ext2.rs
+++ b/tests/integration/ext2.rs
@@ -48,3 +48,15 @@ fn test_read_big_file() {
     let num_blocks = 12 + 256 + (256 * 256) + (256 * 16);
     assert_eq!(fs.read("/big_file").unwrap(), gen_big_file(num_blocks));
 }
+
+#[test]
+fn test_read_file_with_holes() {
+    let fs = load_ext2();
+    let mut expected_data = vec![0xa5; 1024];
+    expected_data.extend(vec![0; 1024]);
+    expected_data.extend(vec![0xa5; 1024]);
+    expected_data.extend(vec![0; 1024]);
+    expected_data.extend(vec![0xa5; 1024]);
+
+    assert_eq!(fs.read("/holes").unwrap(), expected_data);
+}


### PR DESCRIPTION
The block map may contain zeros. Such blocks should be treated as holes rather than actually reading the zero block.

Implement a simple fix in read_inode_file, and add a test.

See https://github.com/nicholasbishop/ext4-view-rs/issues/249 for a possible better fix that will require some refactoring.