### PR TITLE
release: 0.5.1 (take 2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ keywords = ["ext4", "filesystem", "no_std"]
 rust-version = "1.73"
 include = [
     "src/*.rs",
+    "src/iters",
     "LICENSE-APACHE",
     "LICENSE-MIT",
 ]


### PR DESCRIPTION
Previous attempt failed due to missing source files. Fix by adding src/iters to the include list.