### PR TITLE
Use core::error::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+* MSRV increased to `1.81`.
+* The error types now unconditionally implement `core::error::Error`.
+* The `IoError` trait has been removed. `Ext4Read::read` now returns
+  `Box<dyn Error + Send + Sync + 'static>`, and that same type is now
+  stored in `Ext4Error::Io`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/nicholasbishop/ext4-view-rs"
 categories = ["filesystem", "embedded", "no-std"]
 description = "No-std compatible Rust library for reading ext2/ext4 filesystems"
 keywords = ["ext4", "filesystem", "no_std"]
-rust-version = "1.73"
+rust-version = "1.81"
 include = [
     "src/*.rs",
     "src/iters",

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -15,6 +15,7 @@ use crate::path::{Path, PathBuf};
 use crate::util::{read_u16le, read_u32le};
 use crate::Ext4;
 use alloc::rc::Rc;
+use core::error::Error;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::str::Utf8Error;
@@ -53,8 +54,7 @@ impl Display for DirEntryNameError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DirEntryNameError {}
+impl Error for DirEntryNameError {}
 
 /// Name of a [`DirEntry`], stored as a reference.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,12 +8,12 @@
 
 use crate::features::IncompatibleFeatures;
 use alloc::boxed::Box;
-use core::any::Any;
 use core::error::Error;
 use core::fmt::{self, Debug, Display, Formatter};
 
-/// Underlying error type for [`Ext4Error::Io`].
-pub trait IoError: Any + Debug + Display + Send + Sync {}
+/// Boxed error, used for IO errors. This is similar in spirit to
+/// `anyhow::Error`, although a much simpler implementation.
+pub(crate) type BoxedError = Box<dyn Error + Send + Sync + 'static>;
 
 /// Common error type for all [`Ext4`] operations.
 ///
@@ -72,7 +72,7 @@ pub enum Ext4Error {
     /// [`Ext4Read`]: crate::Ext4Read
     Io(
         /// Underlying error.
-        Box<dyn IoError>,
+        BoxedError,
     ),
 
     /// The filesystem is not supported by this library. This does not
@@ -105,7 +105,7 @@ impl Ext4Error {
     }
 
     /// If the error type is [`Ext4Error::Io`], get the underlying error.
-    pub fn as_io(&self) -> Option<&dyn IoError> {
+    pub fn as_io(&self) -> Option<&(dyn Error + Send + Sync + 'static)> {
         if let Self::Io(err) = self {
             Some(&**err)
         } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@
 use crate::features::IncompatibleFeatures;
 use alloc::boxed::Box;
 use core::any::Any;
+use core::error::Error;
 use core::fmt::{self, Debug, Display, Formatter};
 
 /// Underlying error type for [`Ext4Error::Io`].
@@ -140,8 +141,7 @@ impl Display for Ext4Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Ext4Error {}
+impl Error for Ext4Error {}
 
 /// Error type used in [`Ext4Error::Corrupt`] when the filesystem is
 /// corrupt in some way.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ use superblock::Superblock;
 use util::usize_from_u32;
 
 pub use dir_entry::{DirEntry, DirEntryName, DirEntryNameError};
-pub use error::{Corrupt, Ext4Error, Incompatible, IoError};
+pub use error::{Corrupt, Ext4Error, Incompatible};
 pub use features::IncompatibleFeatures;
 pub use file_type::FileType;
 pub use iters::read_dir::ReadDir;

--- a/src/path.rs
+++ b/src/path.rs
@@ -10,6 +10,7 @@ use crate::dir_entry::{DirEntryName, DirEntryNameError};
 use crate::format::{format_bytes_debug, BytesDisplay};
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::error::Error;
 use core::fmt::{self, Debug, Display, Formatter};
 
 /// Error returned when [`Path`] or [`PathBuf`] construction fails.
@@ -34,8 +35,7 @@ impl Display for PathError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PathError {}
+impl Error for PathError {}
 
 /// Reference path type.
 ///

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -9,6 +9,7 @@
 use crate::error::IoError;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::error::Error;
 use core::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "std")]
@@ -76,8 +77,7 @@ impl Display for MemIoError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for MemIoError {}
+impl Error for MemIoError {}
 
 impl Ext4Read for Vec<u8> {
     fn read(


### PR DESCRIPTION
As of Rust 1.81, the `Error` trait is available in `core`, so we can improve the error API of this crate.