### PR TITLE
Simplify error handling in get_dir_entry_via_htree

### DIFF
--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -382,12 +382,9 @@ pub(crate) fn get_dir_entry_via_htree(
             inode.index,
             path.clone(),
         )?;
-        offset_within_block =
-            if let Some(offset) = offset_within_block.checked_add(entry_size) {
-                offset
-            } else {
-                return Err(Corrupt::DirEntry(inode.index.get()).into());
-            };
+        offset_within_block = offset_within_block
+            .checked_add(entry_size)
+            .ok_or(Corrupt::DirEntry(inode.index.get()))?;
         let Some(dir_entry) = dir_entry else {
             continue;
         };


### PR DESCRIPTION
Use `ok_or` instead of explicit if/else.

Note that `Ext4Error::Corrupt` is used explicitly rather than an `into` conversion becausee the compiler doesn't automatically figure out the type in this case.