### PR TITLE
Make BytesDisplay public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-* Add `impl From<Corrupt> for Ext4Error`.
-* Add `impl From<Incompatible> for Ext4Error`.
+* Added `impl From<Corrupt> for Ext4Error`.
+* Added `impl From<Incompatible> for Ext4Error`.
+* Made `BytesDisplay` public.
 
 ## 0.6.1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ pub use dir_entry::{DirEntry, DirEntryName, DirEntryNameError};
 pub use error::{Corrupt, Ext4Error, Incompatible};
 pub use features::IncompatibleFeatures;
 pub use file_type::FileType;
+pub use format::BytesDisplay;
 pub use iters::read_dir::ReadDir;
 pub use metadata::Metadata;
 pub use path::{Component, Components, Path, PathBuf, PathError};


### PR DESCRIPTION
This type is returned by some public methods like `DirEntryName::display`. While it doesn't technically need to be public (it's only used for its `Display` impl), it makes the docs a little nicer.

Also made changelog entries consistently past tense.