### PR TITLE
Use checked arithmetic in the block map module

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -199,6 +199,9 @@ pub enum Corrupt {
         u32,
     ),
 
+    /// A block map is invalid.
+    BlockMap,
+
     /// An extent's magic is invalid.
     ExtentMagic(
         /// Inode number.
@@ -271,6 +274,9 @@ impl Display for Corrupt {
             Self::Inode(inode) => write!(f, "inode {inode} is invalid"),
             Self::SymlinkTarget(inode) => {
                 write!(f, "inode {inode} has an invalid symlink path")
+            }
+            Self::BlockMap => {
+                write!(f, "block map is invalid")
             }
             Self::ExtentMagic(inode) => {
                 write!(f, "extent in inode {inode} has invalid magic")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,11 @@
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![forbid(unsafe_code)]
-#![warn(clippy::as_conversions, clippy::use_self)]
+#![warn(
+    clippy::arithmetic_side_effects,
+    clippy::as_conversions,
+    clippy::use_self
+)]
 #![warn(missing_docs)]
 #![warn(unreachable_pub)]
 


### PR DESCRIPTION
Also enable the `clippy::arithmetic_side_effects` lint for the whole package.