### PR TITLE
Add BlockSize type

### DIFF
--- a/src/block_group.rs
+++ b/src/block_group.rs
@@ -60,6 +60,7 @@ impl BlockGroupDescriptor {
         let bgd_start_block: u32 = if sb.block_size == 1024 { 2 } else { 1 };
         let bgd_per_block = sb
             .block_size
+            .to_u32()
             .checked_div(u32::from(sb.block_group_descriptor_size))?;
         let block_index = bgd_start_block
             .checked_add(bgd_index.checked_div(bgd_per_block)?)?;
@@ -67,7 +68,7 @@ impl BlockGroupDescriptor {
             .checked_mul(u32::from(sb.block_group_descriptor_size))?;
 
         u64::from(block_index)
-            .checked_mul(u64::from(sb.block_size))?
+            .checked_mul(sb.block_size.to_u64())?
             .checked_add(u64::from(offset_within_block))
     }
 

--- a/src/block_size.rs
+++ b/src/block_size.rs
@@ -1,0 +1,89 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::util::usize_from_u32;
+use core::num::NonZero;
+
+/// File system block size.
+///
+/// The block size is guaranteed to be a multiple of `1024` in the range
+/// `1024..=2_147_483_648`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub(crate) struct BlockSize(NonZero<u32>);
+
+impl BlockSize {
+    pub(crate) fn from_superblock_value(log_block_size: u32) -> Option<Self> {
+        let exp = log_block_size.checked_add(10)?;
+        let block_size = 2u32.checked_pow(exp)?;
+        // OK to unwrap: the smallest value of `log_block_size` is 0, so
+        // the smallest value of `block_size` is `2^(0+10)=1024`.
+        Some(Self(NonZero::new(block_size).unwrap()))
+    }
+
+    pub(crate) const fn to_u32(self) -> u32 {
+        self.0.get()
+    }
+
+    pub(crate) const fn to_u64(self) -> u64 {
+        // Cannot use `u64::try_from` in a `const fn`.
+        #[expect(clippy::as_conversions)]
+        {
+            self.0.get() as u64
+        }
+    }
+
+    pub(crate) const fn to_usize(self) -> usize {
+        usize_from_u32(self.0.get())
+    }
+}
+
+impl PartialEq<u32> for BlockSize {
+    fn eq(&self, v: &u32) -> bool {
+        self.to_u32() == *v
+    }
+}
+
+impl PartialEq<BlockSize> for u32 {
+    fn eq(&self, v: &BlockSize) -> bool {
+        *self == v.to_u32()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_block_size_from_superblock_value() {
+        assert_eq!(BlockSize::from_superblock_value(0).unwrap().0.get(), 1024);
+        assert_eq!(BlockSize::from_superblock_value(1).unwrap().0.get(), 2048);
+        assert_eq!(BlockSize::from_superblock_value(2).unwrap().0.get(), 4096);
+        assert_eq!(
+            BlockSize::from_superblock_value(21).unwrap().0.get(),
+            2_147_483_648
+        );
+        assert!(BlockSize::from_superblock_value(22).is_none());
+    }
+
+    #[test]
+    fn test_block_size_to() {
+        let bs = BlockSize::from_superblock_value(0).unwrap();
+        assert_eq!(bs.0.get(), 1024);
+        assert_eq!(bs.to_u32(), 1024u32);
+        assert_eq!(bs.to_u64(), 1024u64);
+        assert_eq!(bs.to_usize(), 1024usize);
+    }
+
+    #[test]
+    fn test_block_size_eq() {
+        let bs = BlockSize::from_superblock_value(0).unwrap();
+        assert!(bs == 1024u32);
+        assert!(1024u32 == bs);
+    }
+}

--- a/src/dir_block.rs
+++ b/src/dir_block.rs
@@ -9,7 +9,7 @@
 use crate::checksum::Checksum;
 use crate::error::{Corrupt, Ext4Error};
 use crate::inode::InodeIndex;
-use crate::util::{read_u16le, read_u32le, usize_from_u32};
+use crate::util::{read_u16le, read_u32le};
 use crate::Ext4;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -53,11 +53,11 @@ impl DirBlock<'_> {
     /// block's checksum will be verified.
     pub(crate) fn read(&self, block: &mut [u8]) -> Result<(), Ext4Error> {
         let block_size = self.fs.0.superblock.block_size;
-        assert_eq!(block.len(), usize_from_u32(block_size));
+        assert_eq!(block.len(), block_size.to_usize());
 
         let start_byte = self
             .block_index
-            .checked_mul(u64::from(block_size))
+            .checked_mul(block_size.to_u64())
             .ok_or(Corrupt::DirEntry(self.dir_inode.get()))?;
         self.fs.read_bytes(start_byte, block)?;
 

--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -354,7 +354,7 @@ pub(crate) fn get_dir_entry_via_htree(
     assert!(inode.flags.contains(InodeFlags::DIRECTORY_HTREE));
 
     let block_size = fs.0.superblock.block_size;
-    let mut block = vec![0; usize_from_u32(block_size)];
+    let mut block = vec![0; block_size.to_usize()];
 
     // Read the first block of the file, which contains the root node of
     // the htree.
@@ -402,10 +402,7 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "std")]
-    use {
-        crate::util::usize_from_u32,
-        crate::{FollowSymlinks, Path, ReadDir},
-    };
+    use crate::{FollowSymlinks, Path, ReadDir};
 
     #[test]
     fn test_internal_node() {
@@ -467,7 +464,7 @@ mod tests {
     fn test_read_dot_or_dotdot() {
         let fs = crate::load_test_disk1();
 
-        let mut block = vec![0; usize_from_u32(fs.0.superblock.block_size)];
+        let mut block = vec![0; fs.0.superblock.block_size.to_usize()];
 
         // Read the root block of an htree.
         let inode = fs

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -270,8 +270,10 @@ fn get_inode_start_byte(ext4: &Ext4, inode: InodeIndex) -> Option<u64> {
     let byte_offset_within_group =
         u64::from(index_within_group).checked_mul(u64::from(sb.inode_size))?;
 
-    let byte_offset_of_group =
-        u64::from(sb.block_size).checked_mul(group.inode_table_first_block)?;
+    let byte_offset_of_group = sb
+        .block_size
+        .to_u64()
+        .checked_mul(group.inode_table_first_block)?;
 
     byte_offset_of_group.checked_add(byte_offset_within_group)
 }

--- a/src/iters/extents.rs
+++ b/src/iters/extents.rs
@@ -230,7 +230,7 @@ impl Extents {
             // find out how much data is in the full child node.
             let mut child_header = [0; ENTRY_SIZE_IN_BYTES];
             let child_start = child_block
-                .checked_mul(u64::from(self.ext4.0.superblock.block_size))
+                .checked_mul(self.ext4.0.superblock.block_size.to_u64())
                 .ok_or_else(|| Corrupt::ExtentBlock(self.inode.get()))?;
             self.ext4.read_bytes(child_start, &mut child_header)?;
             let child_header =

--- a/src/iters/read_dir.rs
+++ b/src/iters/read_dir.rs
@@ -13,7 +13,6 @@ use crate::error::{Corrupt, Ext4Error, Incompatible};
 use crate::inode::{Inode, InodeFlags, InodeIndex};
 use crate::iters::file_blocks::FileBlocks;
 use crate::path::PathBuf;
-use crate::util::usize_from_u32;
 use crate::Ext4;
 use alloc::rc::Rc;
 use alloc::vec;
@@ -84,7 +83,7 @@ impl ReadDir {
             file_blocks: FileBlocks::new(fs.clone(), inode)?,
             block_index: None,
             is_first_block: true,
-            block: vec![0; usize_from_u32(fs.0.superblock.block_size)],
+            block: vec![0; fs.0.superblock.block_size.to_usize()],
             offset_within_block: 0,
             is_done: false,
             has_htree,
@@ -116,7 +115,7 @@ impl ReadDir {
         // If a block has been fully processed, move to the next block
         // on the next iteration.
         let block_size = self.fs.0.superblock.block_size;
-        if self.offset_within_block >= usize_from_u32(block_size) {
+        if self.offset_within_block >= block_size.to_usize() {
             self.is_first_block = false;
             self.block_index = None;
             return Ok(None);

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,8 +18,14 @@ use core::mem::size_of;
 /// Panics if `val` does not fit in this platform's `usize`.
 #[inline]
 #[must_use]
-pub(crate) fn usize_from_u32(val: u32) -> usize {
-    usize::try_from(val).unwrap()
+pub(crate) const fn usize_from_u32(val: u32) -> usize {
+    assert!(size_of::<usize>() >= size_of::<u32>());
+
+    // Cannot use `usize::try_from` in a `const fn`.
+    #[expect(clippy::as_conversions)]
+    {
+        val as usize
+    }
 }
 
 /// Create a `u64` from two `u32` values.


### PR DESCRIPTION
This replaces the raw `u32` value in the superblock. This type more clearly enforces the requirements of ext4 block size: an even multiple of 1024, and in the range of `1024..=2^(10+21)`. It also makes conversions to usize and u64 more convenient.
    
The assert in `block_map.rs` that checks the block size is an even multiple of 4 has been removed, since the type guarantees that.

Also constify `usize_from_u32`.