### PR TITLE
Clarify behavior of block iterators and holes

### DIFF
--- a/src/iters/file_blocks.rs
+++ b/src/iters/file_blocks.rs
@@ -24,8 +24,11 @@ enum FileBlocksInner {
 
 /// Iterator over blocks in a file.
 ///
-/// The iterator produces absolute block indices. Note that no blocks
-/// are produced for holes in the file.
+/// The iterator produces absolute block indices. A block index of zero
+/// indicates a hole.
+///
+/// TODO: files represented with extents do not currently yield anything
+/// for holes. Those blocks are silently skipped over.
 pub(crate) struct FileBlocks(FileBlocksInner);
 
 impl FileBlocks {

--- a/src/iters/file_blocks/block_map.rs
+++ b/src/iters/file_blocks/block_map.rs
@@ -40,6 +40,8 @@ use alloc::vec::Vec;
 /// containing direct indices.
 ///
 /// Indices are only initialized up to the size of the file.
+///
+/// A block index of zero indicates a hole.
 pub(super) struct BlockMap {
     fs: Ext4,
 


### PR DESCRIPTION
`BlockMap`, and by extension `FileBlocks` for block-mapped files, yields holes by returning an index of zero. `ExtentsBlocks`, and by extension `FileBlocks` for extent-mapped files, simply skips over holes.

Right now this difference doesn't much matter. When `FileBlocks` is used to read files, the file is always block mapped, and that code handles holes-as-zero. When `FileBlocks` is used to read directories, there are no holes, so block maps and extents behave the same.

Update docstrings to make the current situation clearer. In an upcoming commit, it will be useful to have extent-mapped files also yield holes by returning zero, so also leave a TODO.