### PR TITLE
Yield holes from ExtentsBlocks

### DIFF
--- a/src/iters/file_blocks.rs
+++ b/src/iters/file_blocks.rs
@@ -26,9 +26,6 @@ enum FileBlocksInner {
 ///
 /// The iterator produces absolute block indices. A block index of zero
 /// indicates a hole.
-///
-/// TODO: files represented with extents do not currently yield anything
-/// for holes. Those blocks are silently skipped over.
 pub(crate) struct FileBlocks(FileBlocksInner);
 
 impl FileBlocks {


### PR DESCRIPTION
All blocks in a file not covered by extents are now yielded as zero indices. This does not change behavior of any current usage, but will be useful for implementing a seekable File type.

Also removed the TODO from FileBlocks.

https://github.com/nicholasbishop/ext4-view-rs/issues/330