### PR TITLE
Add File type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Added `File` type and `Ext4::open`.
 * Added `impl From<Corrupt> for Ext4Error`.
 * Added `impl From<Incompatible> for Ext4Error`.
 * Made `BytesDisplay` public.

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,50 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::error::Ext4Error;
+use crate::inode::Inode;
+use crate::metadata::Metadata;
+use crate::path::Path;
+use crate::resolve::FollowSymlinks;
+use crate::Ext4;
+use core::fmt::{self, Debug, Formatter};
+
+/// An open file within an [`Ext4`] filesystem.
+pub struct File {
+    inode: Inode,
+}
+
+impl File {
+    /// Open the file at `path`.
+    pub(crate) fn open(fs: &Ext4, path: Path<'_>) -> Result<Self, Ext4Error> {
+        let inode = fs.path_to_inode(path, FollowSymlinks::All)?;
+
+        if inode.metadata.is_dir() {
+            return Err(Ext4Error::IsADirectory);
+        }
+        if !inode.metadata.file_type.is_regular_file() {
+            return Err(Ext4Error::IsASpecialFile);
+        }
+
+        Ok(Self { inode })
+    }
+
+    /// Get the file metadata.
+    pub fn metadata(&self) -> &Metadata {
+        &self.inode.metadata
+    }
+}
+
+impl Debug for File {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("File")
+            // Just show the inode index, the full `Inode` output is verbose.
+            .field("inode", &self.inode.index)
+            .finish_non_exhaustive()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ mod dir_htree;
 mod error;
 mod extent;
 mod features;
+mod file;
 mod file_type;
 mod format;
 mod inode;
@@ -147,6 +148,7 @@ use util::usize_from_u32;
 pub use dir_entry::{DirEntry, DirEntryName, DirEntryNameError};
 pub use error::{Corrupt, Ext4Error, Incompatible};
 pub use features::IncompatibleFeatures;
+pub use file::File;
 pub use file_type::FileType;
 pub use format::BytesDisplay;
 pub use iters::read_dir::ReadDir;
@@ -364,6 +366,24 @@ impl Ext4 {
     {
         let path = path.try_into().map_err(|_| Ext4Error::MalformedPath)?;
         resolve::resolve_path(self, path, FollowSymlinks::All).map(|v| v.1)
+    }
+
+    /// Open the file at `path`.
+    ///
+    /// # Errors
+    ///
+    /// An error will be returned if:
+    /// * `path` is not absolute.
+    /// * `path` does not exist.
+    /// * `path` is a directory or special file type.
+    ///
+    /// This is not an exhaustive list of errors, see the
+    /// [crate documentation](crate#errors).
+    pub fn open<'p, P>(&self, path: P) -> Result<File, Ext4Error>
+    where
+        P: TryInto<Path<'p>>,
+    {
+        File::open(self, path.try_into().map_err(|_| Ext4Error::MalformedPath)?)
     }
 
     /// Read the entire contents of a file as raw bytes.

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -12,7 +12,7 @@ use ext4_view::{Corrupt, Ext4, Ext4Error, Incompatible, Path, PathBuf};
 // This function is duplicated in `/src/lib.rs`. We can't import that
 // function here because it is gated by `cfg(test)`, and integration
 // tests compile the crate-under-test without that config.
-fn load_test_disk1() -> Ext4 {
+pub fn load_test_disk1() -> Ext4 {
     // This function executes quickly, so don't bother caching.
     let output = std::process::Command::new("zstd")
         .args([

--- a/tests/integration/file.rs
+++ b/tests/integration/file.rs
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::ext4::load_test_disk1;
+use ext4_view::Ext4Error;
+
+#[test]
+fn test_file_metadata() {
+    let fs = load_test_disk1();
+
+    let file = fs.open("/small_file").unwrap();
+    let metadata = file.metadata();
+
+    assert!(metadata.file_type().is_regular_file());
+    assert!(!metadata.is_dir());
+    assert!(!metadata.is_symlink());
+    assert_eq!(metadata.mode(), 0o644);
+    assert_eq!(metadata.len(), 13);
+}
+
+#[test]
+fn test_file_open_errors() {
+    let fs = load_test_disk1();
+
+    assert!(matches!(
+        fs.open("not_absolute").unwrap_err(),
+        Ext4Error::NotAbsolute
+    ));
+    assert!(matches!(
+        fs.open("/empty_dir").unwrap_err(),
+        Ext4Error::IsADirectory
+    ));
+}
+
+#[test]
+fn test_file_debug() {
+    let fs = load_test_disk1();
+    let file = fs.open("/small_file").unwrap();
+
+    let s = format!("{:?}", file);
+    assert!(s.starts_with("File { inode: "));
+    assert!(s.ends_with(".. }"));
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -8,6 +8,7 @@
 
 mod ext2;
 mod ext4;
+mod file;
 mod path;
 
 /// Get the expected data for the "/holes" file.


### PR DESCRIPTION
A `File` is opened with `Ext4::open`.

For now the only supported operation is getting the file metadata. In later commits, reading and seeking will be added.

https://github.com/nicholasbishop/ext4-view-rs/issues/330