### PR TITLE
Add File::read_bytes

### DIFF
--- a/src/block_size.rs
+++ b/src/block_size.rs
@@ -38,6 +38,16 @@ impl BlockSize {
         }
     }
 
+    pub(crate) const fn to_nz_u64(self) -> NonZero<u64> {
+        // TODO: this would be OK to `unwrap`, but can't use `unwrap` in
+        // a const function until Rust 1.83.
+        if let Some(nz) = NonZero::new(self.to_u64()) {
+            nz
+        } else {
+            unreachable!()
+        }
+    }
+
     pub(crate) const fn to_usize(self) -> usize {
         usize_from_u32(self.0.get())
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -8,15 +8,29 @@
 
 use crate::error::Ext4Error;
 use crate::inode::Inode;
+use crate::iters::file_blocks::FileBlocks;
 use crate::metadata::Metadata;
 use crate::path::Path;
 use crate::resolve::FollowSymlinks;
+use crate::util::usize_from_u32;
 use crate::Ext4;
 use core::fmt::{self, Debug, Formatter};
 
 /// An open file within an [`Ext4`] filesystem.
 pub struct File {
+    fs: Ext4,
     inode: Inode,
+    file_blocks: FileBlocks,
+
+    /// Current byte offset within the file.
+    position: u64,
+
+    /// Current block within the file. This is an absolute block index
+    /// within the filesystem.
+    ///
+    /// If `None`, either the next block needs to be fetched from the
+    /// `file_blocks` iterator, or the end of the file has been reached.
+    block_index: Option<u64>,
 }
 
 impl File {
@@ -31,20 +45,155 @@ impl File {
             return Err(Ext4Error::IsASpecialFile);
         }
 
-        Ok(Self { inode })
+        Ok(Self {
+            fs: fs.clone(),
+            position: 0,
+            file_blocks: FileBlocks::new(fs.clone(), &inode)?,
+            inode,
+            block_index: None,
+        })
     }
 
     /// Get the file metadata.
     pub fn metadata(&self) -> &Metadata {
         &self.inode.metadata
     }
+
+    /// Read bytes from the file into `buf`, returning how many bytes
+    /// were read. The number may be smaller than the length of the
+    /// input buffer.
+    ///
+    /// This advances the position of the file by the number of bytes
+    /// read, so calling `read_bytes` repeatedly can be used to read the
+    /// entire file.
+    ///
+    /// Returns `Ok(0)` if the end of the file has been reached.
+    pub fn read_bytes(
+        &mut self,
+        mut buf: &mut [u8],
+    ) -> Result<usize, Ext4Error> {
+        // Nothing to do if output buffer is empty.
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        // Nothing to do if already at the end of the file.
+        if self.position >= self.inode.metadata.size_in_bytes {
+            return Ok(0);
+        }
+
+        // Get the number of bytes remaining in the file, starting from
+        // the current `position`.
+        //
+        // OK to unwrap: just checked that `position` is less than the
+        // file size.
+        let bytes_remaining = self
+            .inode
+            .metadata
+            .size_in_bytes
+            .checked_sub(self.position)
+            .unwrap();
+
+        // If the the number of bytes remaining is less than the output
+        // buffer length, shrink the buffer.
+        //
+        // If the conversion to `usize` fails, the output buffer is
+        // definitely not larger than the remaining bytes to read.
+        if let Ok(bytes_remaining) = usize::try_from(bytes_remaining) {
+            if buf.len() > bytes_remaining {
+                buf = &mut buf[..bytes_remaining];
+            }
+        }
+
+        let block_size = self.fs.0.superblock.block_size;
+
+        // Get the block to read from.
+        let block_index = if let Some(block_index) = self.block_index {
+            block_index
+        } else {
+            // OK to unwrap: already checked that the position is not at
+            // the end of the file, so there must be at least one more
+            // block to read.
+            let block_index = self.file_blocks.next().unwrap()?;
+
+            self.block_index = Some(block_index);
+
+            block_index
+        };
+
+        // Byte offset within the current block.
+        //
+        // OK to unwrap: block size fits in a `u32`, so an offset within
+        // the block will as well.
+        let offset_within_block: u32 =
+            u32::try_from(self.position % block_size.to_nz_u64()).unwrap();
+
+        // OK to unwrap: `offset_within_block` is always less than or
+        // equal to the block length.
+        //
+        // Note that if this block is at the end of the file, the block
+        // may extend past the actual number of bytes in the file. This
+        // does not matter because the output buffer's length was
+        // already capped earlier against the number of bytes remaining
+        // in the file.
+        let bytes_remaining_in_block: u32 = block_size
+            .to_u32()
+            .checked_sub(offset_within_block)
+            .unwrap();
+
+        // If the output buffer is larger than the number of bytes
+        // remaining in the block, shink the buffer.
+        if buf.len() > usize_from_u32(bytes_remaining_in_block) {
+            buf = &mut buf[..usize_from_u32(bytes_remaining_in_block)];
+        }
+
+        // OK to unwrap: the buffer length has been capped so that it
+        // cannot be larger than the block size, and the block size fits
+        // in a `u32`.
+        let buf_len_u32: u32 = buf.len().try_into().unwrap();
+
+        // Read the block data, or zeros if in a hole.
+        if block_index == 0 {
+            buf.fill(0);
+        } else {
+            let start = block_index
+                .checked_mul(block_size.to_u64())
+                .and_then(|v| v.checked_add(u64::from(offset_within_block)))
+                .ok_or(Ext4Error::FileTooLarge)?;
+            self.fs.read_bytes(start, buf)?;
+        }
+
+        // OK to unwrap: reads don't extend past a block, so this is at
+        // most `block_size`, which always fits in a `u32`.
+        let new_offset_within_block: u32 =
+            offset_within_block.checked_add(buf_len_u32).unwrap();
+
+        // If the end of this block has been reached, clear
+        // `self.block_index` so that the next call fetches a new block
+        // from the iterator.
+        if new_offset_within_block >= block_size.to_u32() {
+            self.block_index = None;
+        }
+
+        // OK to unwrap: the buffer length is capped such that this
+        // calculation is at most the length of the file, which fits in
+        // a `u64`.
+        self.position =
+            self.position.checked_add(u64::from(buf_len_u32)).unwrap();
+
+        Ok(buf.len())
+    }
 }
 
 impl Debug for File {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("File")
-            // Just show the inode index, the full `Inode` output is verbose.
+            // Just show the index from `self.inode`, the full `Inode`
+            // output is verbose.
             .field("inode", &self.inode.index)
+            .field("position", &self.position)
+            // Don't show all fields, as that would make the output less
+            // readable.
             .finish_non_exhaustive()
     }
 }

--- a/tests/integration/ext2.rs
+++ b/tests/integration/ext2.rs
@@ -9,7 +9,7 @@
 use crate::expected_holes_data;
 use ext4_view::Ext4;
 
-fn load_ext2() -> Ext4 {
+pub fn load_ext2() -> Ext4 {
     let output = std::process::Command::new("zstd")
         .args([
             "--decompress",


### PR DESCRIPTION
This does an unbuffered read of file data into a byte buffer. Behavior is compatible with `std::io::Read::read`.

https://github.com/nicholasbishop/ext4-view-rs/issues/330