### PR TITLE
Add optional journal inode to superblock

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -190,6 +190,9 @@ pub enum Corrupt {
     /// The number of inodes per block group is zero.
     InodesPerBlockGroup,
 
+    /// The journal inode in the superblock is invalid.
+    JournalInode,
+
     /// Invalid first data block.
     FirstDataBlock(
         /// First data block.
@@ -288,6 +291,7 @@ impl Display for Corrupt {
             Self::InodesPerBlockGroup => {
                 write!(f, "inodes per block group is zero")
             }
+            Self::JournalInode => write!(f, "invalid journal inode"),
             Self::FirstDataBlock(block) => {
                 write!(f, "invalid first data block: {block}")
             }

--- a/src/features.rs
+++ b/src/features.rs
@@ -72,3 +72,11 @@ bitflags! {
         const ORPHAN_PRESENT = 0x1_0000;
     }
 }
+
+bitflags! {
+    /// Optional file system features.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    pub struct CompatibleFeatures: u32 {
+        const HAS_JOURNAL = 0x4;
+    }
+}


### PR DESCRIPTION
This will be used to read the journal data if the filesystem was not unmounted cleanly.

https://github.com/nicholasbishop/ext4-view-rs/issues/317