### PR TITLE
xtask: Improve command running

### DIFF
--- a/xtask/src/diff_walk.rs
+++ b/xtask/src/diff_walk.rs
@@ -155,19 +155,14 @@ fn is_compressed(path: &Path) -> Result<bool> {
 /// requires elevated permissions.
 pub fn diff_walk(orig_path: &Path) -> Result<()> {
     // Build `mount_and_walk` in release mode.
-    let status = Command::new("cargo")
-        .args([
-            "build",
-            "--release",
-            "--package",
-            "xtask",
-            "--bin",
-            "mount_and_walk",
-        ])
-        .status()?;
-    if !status.success() {
-        bail!("failed to build mount_and_walk");
-    }
+    run_cmd(Command::new("cargo").args([
+        "build",
+        "--release",
+        "--package",
+        "xtask",
+        "--bin",
+        "mount_and_walk",
+    ]))?;
 
     // If the input file is compressed, decompress it and write to a
     // temporary file.

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -31,11 +31,16 @@ pub fn calc_file_sha256(path: &Path) -> Result<String> {
     Ok(format!("{hash:x}"))
 }
 
+fn cmd_to_string(cmd: &Command) -> String {
+    format!("{cmd:?}").replace('"', "")
+}
+
 /// Run a command.
 ///
 /// Return an error if the command fails to launch or if it exits
 /// non-zero.
 pub fn run_cmd(cmd: &mut Command) -> Result<()> {
+    eprintln!("run: {}", cmd_to_string(cmd));
     let program = cmd.get_program().to_string_lossy().into_owned();
     let status = cmd
         .status()
@@ -51,6 +56,7 @@ pub fn run_cmd(cmd: &mut Command) -> Result<()> {
 /// Return an error if the command fails to launch or if it exits
 /// non-zero.
 pub fn capture_cmd(cmd: &mut Command) -> Result<Output> {
+    eprintln!("capture: {}", cmd_to_string(cmd));
     let program = cmd.get_program().to_string_lossy().into_owned();
     let output = cmd
         .output()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -123,13 +123,7 @@ impl DiskParams {
             let path = root.join("owner_file");
             fs::write(&path, [])?;
 
-            let status = Command::new("sudo")
-                .args(["chown", "123:456"])
-                .arg(path)
-                .status()?;
-            if !status.success() {
-                bail!("chmod failed");
-            }
+            run_cmd(Command::new("sudo").args(["chown", "123:456"]).arg(path))?;
         }
 
         // Create some nested directories.

--- a/xtask/src/mount.rs
+++ b/xtask/src/mount.rs
@@ -45,9 +45,10 @@ impl Mount {
 impl Drop for Mount {
     fn drop(&mut self) {
         // Ignore errors in drop.
-        let _ = Command::new("sudo")
-            .arg("umount")
-            .arg(self.mount_point.path())
-            .status();
+        let _ = run_cmd(
+            Command::new("sudo")
+                .arg("umount")
+                .arg(self.mount_point.path()),
+        );
     }
 }


### PR DESCRIPTION
* Consistently use `run_cmd` instead of `cmd.status()`
* Print commands to stdout before running them