### PR TITLE
xtask: Add Mount::unmount

### DIFF
--- a/xtask/src/bin/mount_and_walk.rs
+++ b/xtask/src/bin/mount_and_walk.rs
@@ -160,5 +160,8 @@ fn main() -> Result<()> {
         io::stdout().write_all(&dir_entry.format())?;
         println!();
     }
+
+    mount.unmount()?;
+
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -213,6 +213,8 @@ impl DiskParams {
         // Lock the directory.
         run_cmd(Command::new("fscrypt").arg("lock").arg(encrypted_dir))?;
 
+        mount.unmount()?;
+
         Ok(())
     }
 
@@ -247,6 +249,8 @@ impl DiskParams {
         )?;
 
         create_file_with_holes(&root.join("holes"))?;
+
+        mount.unmount()?;
 
         Ok(())
     }


### PR DESCRIPTION
Use this instead of implicit unmount-on-drop, so that errors can be properly propagated.

The drop impl still unmounts as well, since other error cases (i.e. an error occurring before the call to `unmount`) still need to clean up the mount.