### PR TITLE
xtask: Delete test disk if it already exists

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -75,6 +75,9 @@ struct DiskParams {
 
 impl DiskParams {
     fn create(&self) -> Result<()> {
+        // Delete the file if it already exists.
+        let _ = fs::remove_file(&self.path);
+
         let uid = nix::unistd::getuid();
         let gid = nix::unistd::getgid();
 


### PR DESCRIPTION
When creating a disk with `DiskParams::create`, delete the file if it already exists. This is helpful if a previous run of `cargo xtask create-test-data` failed, as it may have left behind a partially-initialized filesystem, and `mkfs` will then stop with a `Y/N` prompt asking if you want to override the data.