### PR TITLE
Add a skeleton for loading a filesystem journal

### DIFF
--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1,0 +1,34 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::{Ext4, Ext4Error};
+
+#[derive(Debug)]
+pub(crate) struct Journal {
+    // TODO: add journal data.
+}
+
+impl Journal {
+    /// Create an empty journal.
+    pub(crate) fn empty() -> Self {
+        Self {}
+    }
+
+    /// Load a journal from the filesystem.
+    pub(crate) fn load(fs: &Ext4) -> Result<Self, Ext4Error> {
+        let Some(_journal_inode) = fs.0.superblock.journal_inode else {
+            // Return an empty journal if this filesystem does not have
+            // a journal.
+            return Ok(Self::empty());
+        };
+
+        // TODO: actually load the journal.
+
+        Ok(Self {})
+    }
+}


### PR DESCRIPTION
The `Journal` type does not yet contain any data.

There's a circular dependency when loading the journal. The journal needs to be part of the `Ext4` object so that journal data can be used when reading the filesystem. But the journal itself is a file in the filesystem, so reading it requires an `Ext4` object. To resolve this, the `Ext4::load` method creates the filesystem with an empty journal, then loads the journal with that filesystem, and finally mutates the filesystem to use the loaded journal.

https://github.com/nicholasbishop/ext4-view-rs/issues/317