### PR TITLE
Allow loading filesystems with the recovery bit set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Added `Ext4::uuid` to get the filesystem UUID.
 * Made the `Corrupt` type opaque. It is no longer possible to `match` on
   specific types of corruption.
+* Added support for reading filesystems that weren't cleanly unmounted.
 
 ## 0.7.0
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -59,3 +59,24 @@ impl Journal {
         *self.block_map.get(&block_index).unwrap_or(&block_index)
     }
 }
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use crate::test_util::load_compressed_filesystem;
+    use alloc::rc::Rc;
+
+    #[test]
+    fn test_journal() {
+        let mut fs =
+            load_compressed_filesystem("test_disk_4k_block_journal.bin.zst");
+
+        let test_dir = "/dir500";
+
+        // With the journal in place, this directory exists.
+        assert!(fs.exists(test_dir).unwrap());
+
+        // Clear the journal, and verify that the directory no longer exists.
+        Rc::get_mut(&mut fs.0).unwrap().journal.block_map.clear();
+        assert!(!fs.exists(test_dir).unwrap());
+    }
+}

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -7,36 +7,55 @@
 // except according to those terms.
 
 mod block_header;
-#[expect(unused)] // TODO
 mod block_map;
 mod commit_block;
 mod descriptor_block;
-#[expect(unused)] // TODO
 mod superblock;
 
-use crate::{Ext4, Ext4Error};
+use crate::error::Ext4Error;
+use crate::inode::Inode;
+use crate::Ext4;
+use block_map::{load_block_map, BlockMap};
+use superblock::JournalSuperblock;
 
 #[derive(Debug)]
 pub(crate) struct Journal {
-    // TODO: add journal data.
+    block_map: BlockMap,
 }
 
 impl Journal {
     /// Create an empty journal.
     pub(crate) fn empty() -> Self {
-        Self {}
+        Self {
+            block_map: BlockMap::new(),
+        }
     }
 
     /// Load a journal from the filesystem.
+    ///
+    /// If the filesystem has no journal, an empty journal is returned.
+    ///
+    /// Note: ext4 is all little-endian, except for the journal, which
+    /// is all big-endian.
     pub(crate) fn load(fs: &Ext4) -> Result<Self, Ext4Error> {
-        let Some(_journal_inode) = fs.0.superblock.journal_inode else {
+        let Some(journal_inode) = fs.0.superblock.journal_inode else {
             // Return an empty journal if this filesystem does not have
             // a journal.
             return Ok(Self::empty());
         };
 
-        // TODO: actually load the journal.
+        let journal_inode = Inode::read(fs, journal_inode)?;
+        let superblock = JournalSuperblock::load(fs, &journal_inode)?;
+        let block_map = load_block_map(fs, &superblock, &journal_inode)?;
 
-        Ok(Self {})
+        Ok(Self { block_map })
+    }
+
+    /// Map from an absolute block index to a block in the journal.
+    ///
+    /// If the journal does not contain a replacement for the input
+    /// block, the input block is returned.
+    pub(crate) fn map_block_index(&self, block_index: u64) -> u64 {
+        *self.block_map.get(&block_index).unwrap_or(&block_index)
     }
 }

--- a/src/journal/superblock.rs
+++ b/src/journal/superblock.rs
@@ -197,6 +197,28 @@ fn check_incompat_features(
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
+    use crate::test_util::load_compressed_filesystem;
+
+    #[test]
+    fn test_load_journal_superblock() {
+        let fs =
+            load_compressed_filesystem("test_disk_4k_block_journal.bin.zst");
+        let journal_inode =
+            Inode::read(&fs, fs.0.superblock.journal_inode.unwrap()).unwrap();
+        let superblock = JournalSuperblock::load(&fs, &journal_inode).unwrap();
+        assert_eq!(
+            superblock,
+            JournalSuperblock {
+                block_size: 4096,
+                sequence: 3,
+                start_block: 289,
+                uuid: Uuid([
+                    0x6c, 0x48, 0x4f, 0x1b, 0x7f, 0x71, 0x47, 0x4c, 0xa1, 0xf9,
+                    0x3b, 0x50, 0x0c, 0xc1, 0xe2, 0x74
+                ]),
+            }
+        );
+    }
 
     fn write_u32be(bytes: &mut [u8], offset: usize, value: u32) {
         bytes[offset..offset + 4].copy_from_slice(&value.to_be_bytes());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,8 @@ impl Ext4 {
             })
         };
 
+        let block_index = self.0.journal.map_block_index(block_index);
+
         // The first 1024 bytes are reserved for non-filesystem
         // data. This conveniently allows for something like a null
         // pointer check.

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -201,7 +201,6 @@ fn check_incompat_features(
     // relax some of these in the future.
     let required_features = IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY;
     let disallowed_features = IncompatibleFeatures::COMPRESSION
-        | IncompatibleFeatures::RECOVERY
         | IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE
         | IncompatibleFeatures::META_BLOCK_GROUPS
         | IncompatibleFeatures::MULTIPLE_MOUNT_PROTECTION


### PR DESCRIPTION
This is the final step of enabling journal support. Since the test filesystem can now be loaded, this PR also adds some tests.

https://github.com/nicholasbishop/ext4-view-rs/issues/317