### PR TITLE
Simplify implementation of Ext4::read_inode_file

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -48,6 +48,16 @@ impl File {
             return Err(Ext4Error::IsASpecialFile);
         }
 
+        Self::open_inode(fs, inode)
+    }
+
+    /// Open `inode`. Note that unlike `File::open`, this allows any
+    /// type of `inode` to be opened, including directories and
+    /// symlinks. This is used by `Ext4::read_inode_file`.
+    pub(crate) fn open_inode(
+        fs: &Ext4,
+        inode: Inode,
+    ) -> Result<Self, Ext4Error> {
         Ok(Self {
             fs: fs.clone(),
             position: 0,

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -91,7 +91,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Inode {
     /// This inode's index.
     pub(crate) index: InodeIndex,


### PR DESCRIPTION
Use `File` to perform the reads. This greatly simplifies the implementation.
    
There may be some slight loss of performance for extent-based files:
1. Previously only one call to `Ext4::read_bytes` was needed for each extent. Now one call is needed per block in the extent.
2. Previously holes were simply skipped over since the output vec is already zeroed. Now the `File` reader will re-fill those blocks with zeroes.
    
In practice I don't expect any signficant performance impact. We don't currently have real benchmark infrastructure, but I tested this command a few times with and without the changes and did not observe any significant timing difference:
    
    cargo xtask diff-walk test_data/chromiumos_stateful.bin