### PR TITLE
Add extra validity checks for inode and extent node sizes

### DIFF
--- a/src/block_size.rs
+++ b/src/block_size.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use crate::util::usize_from_u32;
+use core::cmp::Ordering;
 use core::num::NonZero;
 
 /// File system block size.
@@ -59,9 +60,39 @@ impl PartialEq<u32> for BlockSize {
     }
 }
 
+impl PartialEq<BlockSize> for u16 {
+    fn eq(&self, v: &BlockSize) -> bool {
+        u32::from(*self) == v.to_u32()
+    }
+}
+
 impl PartialEq<BlockSize> for u32 {
     fn eq(&self, v: &BlockSize) -> bool {
         *self == v.to_u32()
+    }
+}
+
+impl PartialEq<BlockSize> for usize {
+    fn eq(&self, v: &BlockSize) -> bool {
+        *self == v.to_usize()
+    }
+}
+
+impl PartialOrd<BlockSize> for u16 {
+    fn partial_cmp(&self, v: &BlockSize) -> Option<Ordering> {
+        u32::from(*self).partial_cmp(&v.to_u32())
+    }
+}
+
+impl PartialOrd<BlockSize> for u32 {
+    fn partial_cmp(&self, v: &BlockSize) -> Option<Ordering> {
+        self.partial_cmp(&v.to_u32())
+    }
+}
+
+impl PartialOrd<BlockSize> for usize {
+    fn partial_cmp(&self, v: &BlockSize) -> Option<Ordering> {
+        self.partial_cmp(&v.to_usize())
     }
 }
 
@@ -94,6 +125,11 @@ mod tests {
     fn test_block_size_eq() {
         let bs = BlockSize::from_superblock_value(0).unwrap();
         assert!(bs == 1024u32);
+        assert!(1024u16 == bs);
         assert!(1024u32 == bs);
+        assert!(1024usize == bs);
+        assert!(1023u16 < bs);
+        assert!(1023u32 < bs);
+        assert!(1023usize < bs);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -190,6 +190,9 @@ pub enum Corrupt {
     /// The number of inodes per block group is zero.
     InodesPerBlockGroup,
 
+    /// The inode size exceeds the block size.
+    InodeSize,
+
     /// The journal inode in the superblock is invalid.
     JournalInode,
 
@@ -265,6 +268,12 @@ pub enum Corrupt {
         u32,
     ),
 
+    /// An extent node's size exceeds the block size.
+    ExtentNodeSize(
+        /// Inode number.
+        u32,
+    ),
+
     /// A directory block's checksum is invalid.
     DirBlockChecksum(
         /// Inode number.
@@ -291,6 +300,7 @@ impl Display for Corrupt {
             Self::InodesPerBlockGroup => {
                 write!(f, "inodes per block group is zero")
             }
+            Self::InodeSize => write!(f, "inode size is invalid"),
             Self::JournalInode => write!(f, "invalid journal inode"),
             Self::FirstDataBlock(block) => {
                 write!(f, "invalid first data block: {block}")
@@ -327,6 +337,12 @@ impl Display for Corrupt {
             }
             Self::ExtentBlock(inode) => {
                 write!(f, "extent in inode {inode} points to an invalid block")
+            }
+            Self::ExtentNodeSize(inode) => {
+                write!(
+                    f,
+                    "extent in inode {inode} has a node with an invalid size"
+                )
             }
             Self::DirBlockChecksum(inode) => write!(
                 f,

--- a/src/iters/extents.rs
+++ b/src/iters/extents.rs
@@ -251,6 +251,10 @@ impl Extents {
             // `u32`.
             let child_node_size: usize =
                 checksum_offset.checked_add(checksum_size).unwrap();
+            // Extent nodes are not allowed to exceed the block size.
+            if child_node_size > self.ext4.0.superblock.block_size {
+                return Err(Corrupt::ExtentNodeSize(self.inode.get()).into());
+            }
             let mut child_node = vec![0; child_node_size];
             self.ext4.read_bytes(child_start, &mut child_node)?;
 


### PR DESCRIPTION
Inodes and extent nodes never cross block boundaries, so they must be less than or equal to the block size.

Impl more comparison operators for `BlockSize` to make these checks a little cleaner.