### PR TITLE
Deduplicate code for loading compressed test files

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -53,7 +53,7 @@ pub(crate) fn get_dir_entry_inode_by_name(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::load_test_disk1;
+    use crate::test_util::load_test_disk1;
 
     #[test]
     fn test_get_dir_entry_inode_by_name() {

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -449,7 +449,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn test_dir_entry_from_bytes() {
-        let fs = crate::load_test_disk1();
+        let fs = crate::test_util::load_test_disk1();
 
         let inode1 = InodeIndex::new(1).unwrap();
         let inode2 = InodeIndex::new(2).unwrap();

--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -462,7 +462,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn test_read_dot_or_dotdot() {
-        let fs = crate::load_test_disk1();
+        let fs = crate::test_util::load_test_disk1();
 
         let mut block = vec![0; fs.0.superblock.block_size.to_usize()];
 
@@ -531,7 +531,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn test_get_dir_entry_via_htree() {
-        let fs = crate::load_test_disk1();
+        let fs = crate::test_util::load_test_disk1();
 
         // Resolve paths in `/medium_dir` via htree.
         let medium_dir = Path::new("/medium_dir");
@@ -546,7 +546,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn test_block_from_file_block() {
-        let fs = crate::load_test_disk1();
+        let fs = crate::test_util::load_test_disk1();
 
         // Manually construct a simple extent tree containing two
         // extents.

--- a/src/iters/file_blocks/extents_blocks.rs
+++ b/src/iters/file_blocks/extents_blocks.rs
@@ -188,7 +188,8 @@ impl_result_iter!(ExtentsBlocks, u64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{load_test_disk1, FollowSymlinks, Path};
+    use crate::test_util::load_test_disk1;
+    use crate::{FollowSymlinks, Path};
 
     /// Test that `ExtentsBlocks` yields zero for holes.
     ///

--- a/src/iters/read_dir.rs
+++ b/src/iters/read_dir.rs
@@ -172,7 +172,7 @@ impl_result_iter!(ReadDir, DirEntry);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::load_test_disk1;
+    use crate::test_util::load_test_disk1;
 
     #[test]
     fn test_read_dir() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,9 @@ mod resolve;
 mod superblock;
 mod util;
 
+#[cfg(all(test, feature = "std"))]
+mod test_util;
+
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use alloc::string::String;
@@ -545,24 +548,6 @@ impl Debug for Ext4 {
     }
 }
 
-// This function is duplicated in `/tests/integration/ext4.rs`.
-#[cfg(feature = "std")]
-#[cfg(test)]
-fn load_test_disk1() -> Ext4 {
-    // This function executes quickly, so don't bother caching.
-    let output = std::process::Command::new("zstd")
-        .args([
-            "--decompress",
-            // Write to stdout and don't delete the input file.
-            "--stdout",
-            "test_data/test_disk1.bin.zst",
-        ])
-        .output()
-        .unwrap();
-    assert!(output.status.success());
-    Ext4::load(Box::new(output.stdout)).unwrap()
-}
-
 #[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
@@ -570,7 +555,7 @@ mod tests {
 
     #[test]
     fn test_path_to_inode() {
-        let fs = load_test_disk1();
+        let fs = crate::test_util::load_test_disk1();
 
         let follow = FollowSymlinks::All;
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -354,7 +354,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn test_resolve() {
-        let fs = &crate::load_test_disk1();
+        let fs = &crate::test_util::load_test_disk1();
 
         let follow = FollowSymlinks::All;
         let mkp = |s| Path::new(s);

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,0 +1,32 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// In addition to being used as a regular module in lib.rs, this module
+// is used in `tests` via the `include!` macro.
+
+use super::Ext4;
+
+/// Decompress a file with zstd, then load it into an `Ext4`.
+pub(crate) fn load_compressed_filesystem(name: &str) -> Ext4 {
+    // This function executes quickly, so don't bother caching.
+    let output = std::process::Command::new("zstd")
+        .args([
+            "--decompress",
+            // Write to stdout and don't delete the input file.
+            "--stdout",
+            &format!("test_data/{name}"),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    Ext4::load(Box::new(output.stdout)).unwrap()
+}
+
+pub(crate) fn load_test_disk1() -> Ext4 {
+    load_compressed_filesystem("test_disk1.bin.zst")
+}

--- a/tests/integration/ext2.rs
+++ b/tests/integration/ext2.rs
@@ -7,20 +7,11 @@
 // except according to those terms.
 
 use crate::expected_holes_data;
+use crate::test_util::load_compressed_filesystem;
 use ext4_view::Ext4;
 
 pub fn load_ext2() -> Ext4 {
-    let output = std::process::Command::new("zstd")
-        .args([
-            "--decompress",
-            // Write to stdout and don't delete the input file.
-            "--stdout",
-            "test_data/test_disk_ext2.bin.zst",
-        ])
-        .output()
-        .unwrap();
-    assert!(output.status.success());
-    Ext4::load(Box::new(output.stdout)).unwrap()
+    load_compressed_filesystem("test_disk_ext2.bin.zst")
 }
 
 // This function is duplicated in `/xtask/src/main.rs`.

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -7,25 +7,8 @@
 // except according to those terms.
 
 use crate::expected_holes_data;
+use crate::test_util::load_test_disk1;
 use ext4_view::{Corrupt, Ext4, Ext4Error, Incompatible, Path, PathBuf};
-
-// This function is duplicated in `/src/lib.rs`. We can't import that
-// function here because it is gated by `cfg(test)`, and integration
-// tests compile the crate-under-test without that config.
-pub fn load_test_disk1() -> Ext4 {
-    // This function executes quickly, so don't bother caching.
-    let output = std::process::Command::new("zstd")
-        .args([
-            "--decompress",
-            // Write to stdout and don't delete the input file.
-            "--stdout",
-            "test_data/test_disk1.bin.zst",
-        ])
-        .output()
-        .unwrap();
-    assert!(output.status.success());
-    Ext4::load(Box::new(output.stdout)).unwrap()
-}
 
 #[test]
 fn test_ext4_debug() {

--- a/tests/integration/file.rs
+++ b/tests/integration/file.rs
@@ -8,7 +8,7 @@
 
 use crate::expected_holes_data;
 use crate::ext2::load_ext2;
-use crate::ext4::load_test_disk1;
+use crate::test_util::load_test_disk1;
 use ext4_view::Ext4Error;
 
 #[cfg(feature = "std")]

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -11,6 +11,12 @@ mod ext4;
 mod file;
 mod path;
 
+use ext4_view::Ext4;
+
+mod test_util {
+    include!("../../src/test_util.rs");
+}
+
 /// Get the expected data for the "/holes" file.
 ///
 /// Should match `create_file_with_holes` in xtask.


### PR DESCRIPTION
The loading code is now in a `test_util` module in the main package. This can't be used directly from the integration tests (since it is not part of the public API), so it is pasted into the integration tests with the `include!` macro.

In addition to deduplicating code, this will make it easier to load new compressed test files in the future without adding even more duplicated code.