### PR TITLE
Replace Ext4::read_bytes with Ext4::read_from_block

### DIFF
--- a/src/dir_block.rs
+++ b/src/dir_block.rs
@@ -55,11 +55,7 @@ impl DirBlock<'_> {
         let block_size = self.fs.0.superblock.block_size;
         assert_eq!(block.len(), block_size);
 
-        let start_byte = self
-            .block_index
-            .checked_mul(block_size.to_u64())
-            .ok_or(Corrupt::DirEntry(self.dir_inode.get()))?;
-        self.fs.read_bytes(start_byte, block)?;
+        self.fs.read_from_block(self.block_index, 0, block)?;
 
         if !self.fs.has_metadata_checksums() {
             return Ok(());

--- a/src/error.rs
+++ b/src/error.rs
@@ -286,6 +286,18 @@ pub enum Corrupt {
         /// Inode number.
         u32,
     ),
+
+    /// Invalid read of a block.
+    BlockRead {
+        /// Absolute block index.
+        block_index: u64,
+
+        /// Offset in bytes within the block.
+        offset_within_block: u32,
+
+        /// Length in bytes of the read.
+        read_len: usize,
+    },
 }
 
 impl Display for Corrupt {
@@ -350,6 +362,13 @@ impl Display for Corrupt {
             ),
             Self::DirEntry(inode) => {
                 write!(f, "invalid directory entry in inode {inode}")
+            }
+            Self::BlockRead {
+                block_index,
+                offset_within_block,
+                read_len,
+            } => {
+                write!(f, "invalid read of length {read_len} from block {block_index} at offset {offset_within_block}")
             }
         }
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -169,11 +169,8 @@ impl File {
         if block_index == 0 {
             buf.fill(0);
         } else {
-            let start = block_index
-                .checked_mul(block_size.to_u64())
-                .and_then(|v| v.checked_add(u64::from(offset_within_block)))
-                .ok_or(Ext4Error::FileTooLarge)?;
-            self.fs.read_bytes(start, buf)?;
+            self.fs
+                .read_from_block(block_index, offset_within_block, buf)?;
         }
 
         // OK to unwrap: reads don't extend past a block, so this is at

--- a/src/iters/extents.rs
+++ b/src/iters/extents.rs
@@ -229,10 +229,8 @@ impl Extents {
             // Read just the header of the child node. This is needed to
             // find out how much data is in the full child node.
             let mut child_header = [0; ENTRY_SIZE_IN_BYTES];
-            let child_start = child_block
-                .checked_mul(self.ext4.0.superblock.block_size.to_u64())
-                .ok_or_else(|| Corrupt::ExtentBlock(self.inode.get()))?;
-            self.ext4.read_bytes(child_start, &mut child_header)?;
+            self.ext4
+                .read_from_block(child_block, 0, &mut child_header)?;
             let child_header =
                 NodeHeader::from_bytes(&child_header, self.inode)?;
 
@@ -256,7 +254,7 @@ impl Extents {
                 return Err(Corrupt::ExtentNodeSize(self.inode.get()).into());
             }
             let mut child_node = vec![0; child_node_size];
-            self.ext4.read_bytes(child_start, &mut child_node)?;
+            self.ext4.read_from_block(child_block, 0, &mut child_node)?;
 
             // Validating the checksum here covers everything but the
             // root node. The root node is embedded within the inode,

--- a/src/iters/file_blocks/block_map.rs
+++ b/src/iters/file_blocks/block_map.rs
@@ -8,7 +8,7 @@
 
 use crate::inode::Inode;
 use crate::util::read_u32le;
-use crate::{Corrupt, Ext4, Ext4Error};
+use crate::{Ext4, Ext4Error};
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -189,15 +189,8 @@ struct IndirectBlockIter {
 
 impl IndirectBlockIter {
     fn new(fs: Ext4, block_index: u32) -> Result<Self, Ext4Error> {
-        let block_size = fs.0.superblock.block_size;
-
-        let start = u64::from(block_index)
-            .checked_mul(block_size.to_u64())
-            .ok_or(Corrupt::BlockMap)?;
-
-        let mut block = vec![0u8; block_size.to_usize()];
-
-        fs.read_bytes(start, &mut block)?;
+        let mut block = vec![0u8; fs.0.superblock.block_size.to_usize()];
+        fs.read_from_block(u64::from(block_index), 0, &mut block)?;
 
         Ok(Self {
             block,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,25 +252,6 @@ impl Ext4 {
         Inode::read(self, root_inode_index)
     }
 
-    /// Read bytes into `dst`, starting at `start_byte`.
-    fn read_bytes(
-        &self,
-        start_byte: u64,
-        dst: &mut [u8],
-    ) -> Result<(), Ext4Error> {
-        // The first 1024 bytes are reserved for non-filesystem
-        // data. This conveniently allows for something like a null
-        // pointer check; an attempt to read from this area indicates a
-        // logic bug in the library.
-        assert!(start_byte >= 1024, "invalid read offset: {start_byte}");
-
-        self.0
-            .reader
-            .borrow_mut()
-            .read(start_byte, dst)
-            .map_err(Ext4Error::Io)
-    }
-
     /// Read data from a block.
     ///
     /// `block_index`: an absolute block within the filesystem.
@@ -290,7 +271,6 @@ impl Ext4 {
     ///
     /// If any of these conditions are violated, a `Corrupt::BlockRead`
     /// error is returned.
-    #[allow(unused)]
     fn read_from_block(
         &self,
         block_index: u64,


### PR DESCRIPTION
The new function allows reading a single block from the filesystem (or a portion of the block). It prevents reads that cross block boundaries, and checks for a few other invalid cases as well.

The first commit adds the new method, then the following commits switch modules over to it one at a time.
    
The motivation for this change is journal support (https://github.com/nicholasbishop/ext4-view-rs/issues/317). The journal will provide a block index map to redirect reads from the original block to a block in the journal. (For example, the journal might say "don't read block 5 from the filesystem, there's newer data in the journal at block 567"). That implies we need to split reads up into block-sized reads.
    
All of our reads (after https://github.com/nicholasbishop/ext4-view-rs/pull/370) are already suitable for the new interface; we already never read more than one block at a time or read across block boundaries, the new function just formalizes that.

As a nice bonus, reading by block+offset instead of an absolute byte offset is also simpler for most call sites. Most call sites already know the block index and offset, and were multiplying these to get the absolute byte offset; now we can just pass the values directly to Ext4::read_from_block. (The one exception is inodes, where we have to convert from absolute byte index to block+offset.)
