### PR TITLE
Add `TryFrom<OsStr/Path>` for `ext4_view::Path` on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 * Added `Path::to_str` and `PathBuf::to_str`.
+* Implemented `TryFrom<&OsStr> for ext4_view::Path` on all platforms,
+  not just Unix.
+* Implemented `TryFrom<&std::path::PathBuf> for ext4_view::Path` on all
+  platforms, not just Unix.
 
 ## 0.7.0
 

--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -12,7 +12,6 @@
 
 use anyhow::{Context, Result};
 use ext4_view::Ext4;
-use std::ffi::OsString;
 use std::io::{self, ErrorKind, Read, Write};
 use std::{env, process};
 
@@ -36,7 +35,8 @@ fn parse_args() -> Result<(std::path::PathBuf, ext4_view::PathBuf)> {
     }
 
     let filesystem = std::path::PathBuf::from(&args[1]);
-    let path = get_ext4_path(args[2].clone())?;
+    let path = ext4_view::PathBuf::try_from(args[2].clone())
+        .context("Invalid ext4 path")?;
 
     Ok((filesystem, path))
 }
@@ -81,13 +81,4 @@ fn main() -> Result<()> {
             }
         }
     }
-}
-
-fn get_ext4_path(s: OsString) -> Result<ext4_view::PathBuf> {
-    // TODO: implement a better conversion on Windows.
-    // https://github.com/nicholasbishop/ext4-view-rs/issues/361
-    #[cfg(windows)]
-    let s = s.to_str().context("Path is not UTF-8")?;
-
-    ext4_view::PathBuf::try_from(s).context("Invalid ext4 path")
 }

--- a/tests/integration/path.rs
+++ b/tests/integration/path.rs
@@ -8,7 +8,7 @@
 
 use ext4_view::{Component, Path, PathBuf, PathError};
 
-#[cfg(all(feature = "std", unix))]
+#[cfg(feature = "std")]
 use std::ffi::{OsStr, OsString};
 
 #[test]
@@ -60,7 +60,7 @@ fn test_path_construction() {
     assert_eq!(PathBuf::default(), []);
 
     // Successful construction from std types.
-    #[cfg(all(feature = "std", unix))]
+    #[cfg(feature = "std")]
     {
         let src: &OsStr = OsStr::new("abc");
         assert_eq!(Path::try_from(src).unwrap(), expected_path);


### PR DESCRIPTION
Rework the implementation so that it works on all platforms, instead of just Unix. See comment in the try_from impl -- some assumptions are made about the behavior of `std`, but reasonable ones I think.

Note that conversion in the other direction (ext4_view's Path/PathBuf to OsStr/OsString) is still only implemented on Unix for now.

https://github.com/nicholasbishop/ext4-view-rs/issues/361