### PR TITLE
Hide the internals of the `Corrupt` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Added `Path::to_str` and `PathBuf::to_str`.
 * Added `Ext4::label` to get the filesystem label.
 * Added `Ext4::uuid` to get the filesystem UUID.
+* Made the `Corrupt` type opaque. It is no longer possible to `match` on
+  specific types of corruption.
 
 ## 0.7.0
 

--- a/src/dir_block.rs
+++ b/src/dir_block.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use crate::checksum::Checksum;
-use crate::error::{Corrupt, Ext4Error};
+use crate::error::{CorruptKind, Ext4Error};
 use crate::inode::InodeIndex;
 use crate::util::{read_u16le, read_u32le};
 use crate::Ext4;
@@ -73,7 +73,7 @@ impl DirBlock<'_> {
         if actual_checksum.finalize() == expected_checksum {
             Ok(())
         } else {
-            Err(Corrupt::DirBlockChecksum(self.dir_inode.get()).into())
+            Err(CorruptKind::DirBlockChecksum(self.dir_inode.get()).into())
         }
     }
 

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::error::{Corrupt, Ext4Error};
+use crate::error::{CorruptKind, Ext4Error};
 use crate::file_type::FileType;
 use crate::format::{format_bytes_debug, BytesDisplay};
 use crate::inode::{Inode, InodeIndex};
@@ -237,7 +237,7 @@ impl DirEntry {
     ) -> Result<(Option<Self>, usize), Ext4Error> {
         const NAME_OFFSET: usize = 8;
 
-        let err = || Corrupt::DirEntry(inode.get()).into();
+        let err = || CorruptKind::DirEntry(inode.get()).into();
 
         // Check size (the full entry will usually be larger than this),
         // but these header fields must be present.
@@ -492,7 +492,7 @@ mod tests {
         // Error: not enough data.
         let err = DirEntry::from_bytes(fs.clone(), &[], inode1, path.clone())
             .unwrap_err();
-        assert_eq!(*err.as_corrupt().unwrap(), Corrupt::DirEntry(1));
+        assert_eq!(*err.as_corrupt().unwrap(), CorruptKind::DirEntry(1));
 
         // Error: not enough data for the name.
         let mut bytes = Vec::new();

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -492,7 +492,7 @@ mod tests {
         // Error: not enough data.
         let err = DirEntry::from_bytes(fs.clone(), &[], inode1, path.clone())
             .unwrap_err();
-        assert_eq!(*err.as_corrupt().unwrap(), CorruptKind::DirEntry(1));
+        assert_eq!(*err.as_corrupt().unwrap(), CorruptKind::DirEntry(1).into());
 
         // Error: not enough data for the name.
         let mut bytes = Vec::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -170,14 +170,20 @@ impl From<Ext4Error> for std::io::Error {
     }
 }
 
-// TODO
-pub(crate) type CorruptKind = Corrupt;
-
 /// Error type used in [`Ext4Error::Corrupt`] when the filesystem is
 /// corrupt in some way.
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Corrupt(pub(crate) CorruptKind);
+
+impl Display for Corrupt {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        <CorruptKind as Display>::fmt(&self.0, f)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum Corrupt {
+pub(crate) enum CorruptKind {
     /// Superblock magic is invalid.
     SuperblockMagic,
 
@@ -300,7 +306,7 @@ pub enum Corrupt {
     },
 }
 
-impl Display for Corrupt {
+impl Display for CorruptKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::SuperblockMagic => write!(f, "invalid superblock magic"),
@@ -374,6 +380,18 @@ impl Display for Corrupt {
 impl From<Corrupt> for Ext4Error {
     fn from(c: Corrupt) -> Self {
         Self::Corrupt(c)
+    }
+}
+
+impl From<CorruptKind> for Corrupt {
+    fn from(c: CorruptKind) -> Self {
+        Self(c)
+    }
+}
+
+impl From<CorruptKind> for Ext4Error {
+    fn from(c: CorruptKind) -> Self {
+        Self::Corrupt(Corrupt(c))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -238,9 +238,6 @@ pub enum Corrupt {
     /// The number of blocks in a file exceeds 2^32.
     TooManyBlocksInFile,
 
-    /// A block map is invalid.
-    BlockMap,
-
     /// An extent's magic is invalid.
     ExtentMagic(
         /// Inode number.
@@ -335,9 +332,6 @@ impl Display for Corrupt {
                 write!(f, "inode {inode} has an invalid symlink path")
             }
             Self::TooManyBlocksInFile => write!(f, "too many blocks in file"),
-            Self::BlockMap => {
-                write!(f, "block map is invalid")
-            }
             Self::ExtentMagic(inode) => {
                 write!(f, "extent in inode {inode} has invalid magic")
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -170,6 +170,9 @@ impl From<Ext4Error> for std::io::Error {
     }
 }
 
+// TODO
+pub(crate) type CorruptKind = Corrupt;
+
 /// Error type used in [`Ext4Error::Corrupt`] when the filesystem is
 /// corrupt in some way.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -162,7 +162,7 @@ impl Inode {
             // Ext4 allows at most `2^32` blocks in a file.
             .try_into()
             .map_err(|_| {
-                Ext4Error::Corrupt(CorruptKind::TooManyBlocksInFile)
+                Ext4Error::Corrupt(CorruptKind::TooManyBlocksInFile.into())
             })?;
 
         Ok((

--- a/src/iters/file_blocks/extents_blocks.rs
+++ b/src/iters/file_blocks/extents_blocks.rs
@@ -6,10 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::error::{CorruptKind, Ext4Error};
 use crate::extent::Extent;
 use crate::inode::{Inode, InodeIndex};
 use crate::iters::extents::Extents;
-use crate::{Corrupt, Ext4, Ext4Error};
+use crate::Ext4;
 
 /// Iterator over blocks in a file that uses extents.
 ///
@@ -147,7 +148,7 @@ impl ExtentsBlocks {
         let block = extent
             .start_block
             .checked_add(u64::from(self.block_within_extent))
-            .ok_or(Corrupt::ExtentBlock(self.inode.get()))?;
+            .ok_or(CorruptKind::ExtentBlock(self.inode.get()))?;
 
         // OK to unwrap: `block_within_extent` is less than `num_blocks`
         // (checked above) so adding `1` cannot fail.

--- a/src/iters/read_dir.rs
+++ b/src/iters/read_dir.rs
@@ -9,7 +9,7 @@
 use crate::checksum::Checksum;
 use crate::dir_block::DirBlock;
 use crate::dir_entry::DirEntry;
-use crate::error::{Corrupt, Ext4Error, Incompatible};
+use crate::error::{CorruptKind, Ext4Error, Incompatible};
 use crate::inode::{Inode, InodeFlags, InodeIndex};
 use crate::iters::file_blocks::FileBlocks;
 use crate::path::PathBuf;
@@ -144,7 +144,7 @@ impl ReadDir {
         self.offset_within_block = self
             .offset_within_block
             .checked_add(entry_size)
-            .ok_or(Corrupt::DirEntry(self.inode.get()))?;
+            .ok_or(CorruptKind::DirEntry(self.inode.get()))?;
 
         Ok(entry)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,11 +295,14 @@ impl Ext4 {
         dst: &mut [u8],
     ) -> Result<(), Ext4Error> {
         let err = || {
-            Ext4Error::Corrupt(CorruptKind::BlockRead {
-                block_index,
-                offset_within_block,
-                read_len: dst.len(),
-            })
+            Ext4Error::Corrupt(
+                CorruptKind::BlockRead {
+                    block_index,
+                    offset_within_block,
+                    read_len: dst.len(),
+                }
+                .into(),
+            )
         };
 
         // The first 1024 bytes are reserved for non-filesystem
@@ -636,7 +639,7 @@ mod tests {
         // Invalid superblock.
         assert!(matches!(
             Ext4::load(Box::new(vec![0; 2048])).unwrap_err(),
-            Ext4Error::Corrupt(CorruptKind::SuperblockMagic)
+            Ext4Error::Corrupt(Corrupt(CorruptKind::SuperblockMagic))
         ));
 
         // Not enough data to read the block group descriptors.
@@ -652,7 +655,9 @@ mod tests {
         fs_data.resize(3048usize, 0u8);
         assert!(matches!(
             Ext4::load(Box::new(fs_data.clone())).unwrap_err(),
-            Ext4Error::Corrupt(CorruptKind::BlockGroupDescriptorChecksum(0))
+            Ext4Error::Corrupt(Corrupt(
+                CorruptKind::BlockGroupDescriptorChecksum(0)
+            ))
         ));
     }
 
@@ -670,7 +675,7 @@ mod tests {
                 .unwrap_err()
                 .as_corrupt()
                 .unwrap(),
-            CorruptKind::InvalidBlockSize
+            CorruptKind::InvalidBlockSize.into()
         );
     }
 
@@ -684,6 +689,7 @@ mod tests {
             offset_within_block,
             read_len,
         }
+        .into()
     }
 
     /// Test that reading from the first 1024 bytes of the file fails.

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -224,6 +224,7 @@ fn check_incompat_features(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::Corrupt;
 
     #[test]
     fn test_superblock() {
@@ -315,7 +316,7 @@ mod tests {
         data[0x150..0x154].copy_from_slice(&[0xff; 4]);
         assert!(matches!(
             Superblock::from_bytes(&data).unwrap_err(),
-            Ext4Error::Corrupt(CorruptKind::TooManyBlockGroups)
+            Ext4Error::Corrupt(Corrupt(CorruptKind::TooManyBlockGroups))
         ));
     }
 
@@ -326,7 +327,7 @@ mod tests {
         data[0x58..0x5a].copy_from_slice(&1025u16.to_le_bytes());
         assert!(matches!(
             Superblock::from_bytes(&data).unwrap_err(),
-            Ext4Error::Corrupt(CorruptKind::InodeSize)
+            Ext4Error::Corrupt(Corrupt(CorruptKind::InodeSize))
         ));
     }
 
@@ -339,7 +340,7 @@ mod tests {
         data[0x284] = 0xff;
         assert!(matches!(
             Superblock::from_bytes(&data).unwrap_err(),
-            Ext4Error::Corrupt(CorruptKind::SuperblockChecksum)
+            Ext4Error::Corrupt(Corrupt(CorruptKind::SuperblockChecksum))
         ));
     }
 


### PR DESCRIPTION
With this change, users can no longer match on the specific type of corruption. This avoids exposing too many internal details of the library in the API, which makes it easier to avoid semver-breaking changes.

Most of the changes are mechanical renames. A few tests moved out of `integration` because they now need access to private corruption types. The more interesting changes are in `errors.rs`.

https://github.com/nicholasbishop/ext4-view-rs/issues/389