### PR TITLE
Make the CorruptKind field of Corrupt private

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -176,7 +176,7 @@ impl From<Ext4Error> for std::io::Error {
 /// Error type used in [`Ext4Error::Corrupt`] when the filesystem is
 /// corrupt in some way.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Corrupt(pub(crate) CorruptKind);
+pub struct Corrupt(CorruptKind);
 
 impl Display for Corrupt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -376,6 +376,16 @@ impl Display for CorruptKind {
             } => {
                 write!(f, "invalid read of length {read_len} from block {block_index} at offset {offset_within_block}")
             }
+        }
+    }
+}
+
+impl PartialEq<CorruptKind> for Ext4Error {
+    fn eq(&self, ck: &CorruptKind) -> bool {
+        if let Self::Corrupt(c) = self {
+            c.0 == *ck
+        } else {
+            false
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,10 +638,10 @@ mod tests {
         ));
 
         // Invalid superblock.
-        assert!(matches!(
+        assert_eq!(
             Ext4::load(Box::new(vec![0; 2048])).unwrap_err(),
-            Ext4Error::Corrupt(Corrupt(CorruptKind::SuperblockMagic))
-        ));
+            CorruptKind::SuperblockMagic
+        );
 
         // Not enough data to read the block group descriptors.
         let mut fs_data = vec![0; 2048];
@@ -654,12 +654,10 @@ mod tests {
 
         // Invalid block group descriptor checksum.
         fs_data.resize(3048usize, 0u8);
-        assert!(matches!(
+        assert_eq!(
             Ext4::load(Box::new(fs_data.clone())).unwrap_err(),
-            Ext4Error::Corrupt(Corrupt(
-                CorruptKind::BlockGroupDescriptorChecksum(0)
-            ))
-        ));
+            CorruptKind::BlockGroupDescriptorChecksum(0)
+        );
     }
 
     /// Test that loading the data from

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -224,7 +224,6 @@ fn check_incompat_features(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::Corrupt;
 
     #[test]
     fn test_superblock() {
@@ -314,10 +313,10 @@ mod tests {
         // Set `s_blocks_count_hi` to a very large value so that
         // `num_block_groups` no longer fits in a `u32`.
         data[0x150..0x154].copy_from_slice(&[0xff; 4]);
-        assert!(matches!(
+        assert_eq!(
             Superblock::from_bytes(&data).unwrap_err(),
-            Ext4Error::Corrupt(Corrupt(CorruptKind::TooManyBlockGroups))
-        ));
+            CorruptKind::TooManyBlockGroups
+        );
     }
 
     #[test]
@@ -325,10 +324,10 @@ mod tests {
         let mut data =
             include_bytes!("../test_data/raw_superblock.bin").to_vec();
         data[0x58..0x5a].copy_from_slice(&1025u16.to_le_bytes());
-        assert!(matches!(
+        assert_eq!(
             Superblock::from_bytes(&data).unwrap_err(),
-            Ext4Error::Corrupt(Corrupt(CorruptKind::InodeSize))
-        ));
+            CorruptKind::InodeSize
+        );
     }
 
     #[test]
@@ -338,10 +337,10 @@ mod tests {
         // Modify a reserved byte. Nothing currently uses this data, but
         // it is still part of the checksum.
         data[0x284] = 0xff;
-        assert!(matches!(
+        assert_eq!(
             Superblock::from_bytes(&data).unwrap_err(),
-            Ext4Error::Corrupt(Corrupt(CorruptKind::SuperblockChecksum))
-        ));
+            CorruptKind::SuperblockChecksum
+        );
     }
 
     /// Test that an error is returned if an unknown incompatible


### PR DESCRIPTION
To enable this, add `impl PartialEq<CorruptKind> for Ext4Error` so that tests can directly compare instead of using `matches!`. This has the nice side effect of making tests slightly shorter.