### PR TITLE
Add code for parsing journal block headers

### DIFF
--- a/src/journal.rs
+++ b/src/journal.rs
@@ -6,6 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[expect(unused)] // TODO
+mod block_header;
+
 use crate::{Ext4, Ext4Error};
 
 #[derive(Debug)]

--- a/src/journal/block_header.rs
+++ b/src/journal/block_header.rs
@@ -1,0 +1,84 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::error::Ext4Error;
+use crate::util::read_u32be;
+
+/// Header at the start of every non-data block in the journal.
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct JournalBlockHeader {
+    pub(super) block_type: JournalBlockType,
+    pub(super) sequence: u32,
+}
+
+impl JournalBlockHeader {
+    pub(super) const MAGIC: u32 = 0xc03b3998;
+
+    /// Read a `JournalBlockHeader` from raw bytes.
+    ///
+    /// If the bytes do not start with the expected magic number, return
+    /// `Ok(None)`.
+    pub(super) fn read_bytes(bytes: &[u8]) -> Result<Option<Self>, Ext4Error> {
+        // Return early if this is not a journal block.
+        let h_magic = read_u32be(bytes, 0x0);
+        if h_magic != Self::MAGIC {
+            return Ok(None);
+        }
+
+        let h_blocktype = read_u32be(bytes, 0x4);
+        let h_sequence = read_u32be(bytes, 0x8);
+
+        Ok(Some(Self {
+            block_type: JournalBlockType(h_blocktype),
+            sequence: h_sequence,
+        }))
+    }
+}
+
+/// Journal block type.
+///
+/// This is represented as a wrapper around a `u32` rather than an
+/// `enum` so that unknown values can be treated as unsupported rather
+/// than being unrepresentable states.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct JournalBlockType(pub(super) u32);
+
+impl JournalBlockType {
+    pub(super) const DESCRIPTOR: Self = Self(1);
+    pub(super) const COMMIT: Self = Self(2);
+    pub(super) const SUPERBLOCK_V2: Self = Self(4);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_journal_block_header_missing_magic() {
+        let bytes = [0; 12];
+        assert!(JournalBlockHeader::read_bytes(&bytes).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_journal_block_header_successful_read() {
+        let mut bytes = [0; 12];
+        // Set magic.
+        bytes[..4].copy_from_slice(&JournalBlockHeader::MAGIC.to_be_bytes());
+        // Set block type.
+        bytes[4..8].copy_from_slice(&123u32.to_be_bytes());
+        // Set sequence.
+        bytes[8..12].copy_from_slice(&456u32.to_be_bytes());
+        assert_eq!(
+            JournalBlockHeader::read_bytes(&bytes).unwrap().unwrap(),
+            JournalBlockHeader {
+                block_type: JournalBlockType(123),
+                sequence: 456,
+            }
+        );
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -69,3 +69,17 @@ pub(crate) fn read_u32le(bytes: &[u8], offset: usize) -> u32 {
     let bytes = bytes.get(offset..end).unwrap();
     u32::from_le_bytes(bytes.try_into().unwrap())
 }
+
+/// Read a big-endian [`u32`] from `bytes` at `offset`.
+///
+/// # Panics
+///
+/// Panics if `bytes` is not large enough to read four bytes at `offset`.
+#[inline]
+#[must_use]
+pub(crate) fn read_u32be(bytes: &[u8], offset: usize) -> u32 {
+    // OK to unwrap: these panics are described in the docstring.
+    let end = offset.checked_add(size_of::<u32>()).unwrap();
+    let bytes = bytes.get(offset..end).unwrap();
+    u32::from_be_bytes(bytes.try_into().unwrap())
+}


### PR DESCRIPTION
This is `expect(unused)` until more of the journal code is added.

https://github.com/nicholasbishop/ext4-view-rs/issues/317