### PR TITLE
Use InodeIndex instead of u32 in CorruptKind variants

### DIFF
--- a/src/dir_block.rs
+++ b/src/dir_block.rs
@@ -73,7 +73,7 @@ impl DirBlock<'_> {
         if actual_checksum.finalize() == expected_checksum {
             Ok(())
         } else {
-            Err(CorruptKind::DirBlockChecksum(self.dir_inode.get()).into())
+            Err(CorruptKind::DirBlockChecksum(self.dir_inode).into())
         }
     }
 

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -237,7 +237,7 @@ impl DirEntry {
     ) -> Result<(Option<Self>, usize), Ext4Error> {
         const NAME_OFFSET: usize = 8;
 
-        let err = || CorruptKind::DirEntry(inode.get()).into();
+        let err = || CorruptKind::DirEntry(inode).into();
 
         // Check size (the full entry will usually be larger than this),
         // but these header fields must be present.
@@ -492,7 +492,10 @@ mod tests {
         // Error: not enough data.
         let err = DirEntry::from_bytes(fs.clone(), &[], inode1, path.clone())
             .unwrap_err();
-        assert_eq!(*err.as_corrupt().unwrap(), CorruptKind::DirEntry(1).into());
+        assert_eq!(
+            *err.as_corrupt().unwrap(),
+            CorruptKind::DirEntry(inode1).into()
+        );
 
         // Error: not enough data for the name.
         let mut bytes = Vec::new();

--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -89,7 +89,7 @@ impl<'a> InternalNode<'a> {
     /// Create an `InternalNode` from raw bytes. These bytes come from a
     /// directory block, see [`from_root_block`] and [`from_non_root_block`].
     fn new(mut bytes: &'a [u8], inode: InodeIndex) -> Result<Self, Ext4Error> {
-        let err = CorruptKind::DirEntry(inode.get()).into();
+        let err = CorruptKind::DirEntry(inode).into();
 
         // At least the header entry must be present.
         if bytes.len() < Self::ENTRY_SIZE {
@@ -177,7 +177,7 @@ fn read_root_block(
     // Get the first block.
     let block_index = file_blocks
         .next()
-        .ok_or_else(|| CorruptKind::DirEntry(inode.index.get()))??;
+        .ok_or(CorruptKind::DirEntry(inode.index))??;
 
     // Read the first block of the extent.
     let dir_block = DirBlock {
@@ -204,7 +204,7 @@ fn read_dot_or_dotdot(
     name: DirEntryName<'_>,
     block: &[u8],
 ) -> Result<Option<DirEntry>, Ext4Error> {
-    let corrupt = || CorruptKind::DirEntry(inode.index.get()).into();
+    let corrupt = || CorruptKind::DirEntry(inode.index).into();
 
     let offset = if name == "." {
         0
@@ -240,13 +240,13 @@ fn find_extent_for_block(
         let start = extent.block_within_file;
         let end = start
             .checked_add(u32::from(extent.num_blocks))
-            .ok_or(CorruptKind::DirEntry(inode.index.get()))?;
+            .ok_or(CorruptKind::DirEntry(inode.index))?;
         if block >= start && block < end {
             return Ok(extent);
         }
     }
 
-    Err(CorruptKind::DirEntry(inode.index.get()).into())
+    Err(CorruptKind::DirEntry(inode.index).into())
 }
 
 /// Convert from a block offset within a file to an absolute block index.
@@ -259,17 +259,17 @@ fn block_from_file_block(
         let extent = find_extent_for_block(fs, inode, relative_block)?;
         let block_within_extent = relative_block
             .checked_sub(extent.block_within_file)
-            .ok_or(CorruptKind::DirEntry(inode.index.get()))?;
+            .ok_or(CorruptKind::DirEntry(inode.index))?;
         let absolute_block = extent
             .start_block
             .checked_add(u64::from(block_within_extent))
-            .ok_or(CorruptKind::DirEntry(inode.index.get()))?;
+            .ok_or(CorruptKind::DirEntry(inode.index))?;
         Ok(absolute_block)
     } else {
         let mut block_map = FileBlocks::new(fs.clone(), inode)?;
         block_map
             .nth(usize_from_u32(relative_block))
-            .ok_or_else(|| CorruptKind::DirEntry(inode.index.get()))?
+            .ok_or(CorruptKind::DirEntry(inode.index))?
     }
 }
 
@@ -302,7 +302,7 @@ fn find_leaf_node(
     let hash = dir_hash_md4_half(name, &fs.0.superblock.htree_hash_seed);
     let mut child_block_relative = root_node
         .lookup_block_by_hash(hash)
-        .ok_or(CorruptKind::DirEntry(inode.index.get()))?;
+        .ok_or(CorruptKind::DirEntry(inode.index))?;
 
     // Descend through the tree one level at a time. The first iteration
     // of the loop goes from the root node to a child. The last
@@ -330,7 +330,7 @@ fn find_leaf_node(
                 InternalNode::from_non_root_block(block, inode.index)?;
             child_block_relative = inner_node
                 .lookup_block_by_hash(hash)
-                .ok_or(CorruptKind::DirEntry(inode.index.get()))?;
+                .ok_or(CorruptKind::DirEntry(inode.index))?;
         }
     }
 
@@ -384,7 +384,7 @@ pub(crate) fn get_dir_entry_via_htree(
         )?;
         offset_within_block = offset_within_block
             .checked_add(entry_size)
-            .ok_or(CorruptKind::DirEntry(inode.index.get()))?;
+            .ok_or(CorruptKind::DirEntry(inode.index))?;
         let Some(dir_entry) = dir_entry else {
             continue;
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use crate::features::IncompatibleFeatures;
+use crate::inode::InodeIndex;
 use alloc::boxed::Box;
 use core::error::Error;
 use core::fmt::{self, Debug, Display, Formatter};
@@ -227,74 +228,41 @@ pub(crate) enum CorruptKind {
     ),
 
     /// An inode's checksum is invalid.
-    InodeChecksum(
-        /// Inode number.
-        u32,
-    ),
+    InodeChecksum(InodeIndex),
 
     /// An inode is invalid.
-    Inode(
-        /// Inode number.
-        u32,
-    ),
+    Inode(InodeIndex),
 
     /// The target of a symlink is not a valid path.
-    SymlinkTarget(
-        /// Inode number.
-        u32,
-    ),
+    SymlinkTarget(InodeIndex),
 
     /// The number of blocks in a file exceeds 2^32.
     TooManyBlocksInFile,
 
     /// An extent's magic is invalid.
-    ExtentMagic(
-        /// Inode number.
-        u32,
-    ),
+    ExtentMagic(InodeIndex),
 
     /// An extent's checksum is invalid.
-    ExtentChecksum(
-        /// Inode number.
-        u32,
-    ),
+    ExtentChecksum(InodeIndex),
 
     /// An extent's depth is greater than five.
-    ExtentDepth(
-        /// Inode number.
-        u32,
-    ),
+    ExtentDepth(InodeIndex),
 
     /// Not enough data is present to read an extent node.
-    ExtentNotEnoughData(
-        /// Inode number.
-        u32,
-    ),
+    ExtentNotEnoughData(InodeIndex),
 
     /// An extent points to an invalid block.
-    ExtentBlock(
-        /// Inode number.
-        u32,
-    ),
+    ExtentBlock(InodeIndex),
 
     /// An extent node's size exceeds the block size.
-    ExtentNodeSize(
-        /// Inode number.
-        u32,
-    ),
+    ExtentNodeSize(InodeIndex),
 
     /// A directory block's checksum is invalid.
-    DirBlockChecksum(
-        /// Inode number.
-        u32,
-    ),
+    DirBlockChecksum(InodeIndex),
 
     // TODO: consider breaking this down into more specific problems.
     /// A directory entry is invalid.
-    DirEntry(
-        /// Inode number.
-        u32,
-    ),
+    DirEntry(InodeIndex),
 
     /// Invalid read of a block.
     BlockRead {

--- a/src/iters/file_blocks/extents_blocks.rs
+++ b/src/iters/file_blocks/extents_blocks.rs
@@ -148,7 +148,7 @@ impl ExtentsBlocks {
         let block = extent
             .start_block
             .checked_add(u64::from(self.block_within_extent))
-            .ok_or(CorruptKind::ExtentBlock(self.inode.get()))?;
+            .ok_or(CorruptKind::ExtentBlock(self.inode))?;
 
         // OK to unwrap: `block_within_extent` is less than `num_blocks`
         // (checked above) so adding `1` cannot fail.

--- a/src/iters/read_dir.rs
+++ b/src/iters/read_dir.rs
@@ -144,7 +144,7 @@ impl ReadDir {
         self.offset_within_block = self
             .offset_within_block
             .checked_add(entry_size)
-            .ok_or(CorruptKind::DirEntry(self.inode.get()))?;
+            .ok_or(CorruptKind::DirEntry(self.inode))?;
 
         Ok(entry)
     }


### PR DESCRIPTION
The interesting change is in `error.rs`, changing all of the `/// Inode number` fields to use the `InodeIndex` type. Also removed inner docstrings from those fields, since the type name is sufficiently clear.

The rest of the changes are mechanical compile/lint fixes.