### PR TITLE
Small improvements to error formatting

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -176,8 +176,14 @@ impl From<Ext4Error> for std::io::Error {
 
 /// Error type used in [`Ext4Error::Corrupt`] when the filesystem is
 /// corrupt in some way.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Corrupt(CorruptKind);
+
+impl Debug for Corrupt {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        <CorruptKind as Debug>::fmt(&self.0, f)
+    }
+}
 
 impl Display for Corrupt {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -532,7 +538,7 @@ mod tests {
 
         assert_eq!(
             format!("{err:?}"),
-            "Corrupt(Corrupt(BlockRead { block_index: 123, offset_within_block: 456, read_len: 789 }))"
+            "Corrupt(BlockRead { block_index: 123, offset_within_block: 456, read_len: 789 })"
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,8 +139,8 @@ impl Display for Ext4Error {
             // TODO: if the `Error` trait ever makes it into core, stop
             // printing `err` here and return it via `Error::source` instead.
             Self::Io(err) => write!(f, "io error: {err}"),
-            Self::Incompatible(i) => write!(f, "incompatible: {i}"),
-            Self::Corrupt(c) => write!(f, "corrupt: {c}"),
+            Self::Incompatible(i) => write!(f, "incompatible filesystem: {i}"),
+            Self::Corrupt(c) => write!(f, "corrupt filesystem: {c}"),
         }
     }
 }
@@ -527,7 +527,7 @@ mod tests {
 
         assert_eq!(
             format!("{err}"),
-            "corrupt: invalid read of length 789 from block 123 at offset 456"
+            "corrupt filesystem: invalid read of length 789 from block 123 at offset 456"
         );
 
         assert_eq!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -506,3 +506,33 @@ impl Display for Incompatible {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test the `Display` and `Debug` impls for a corruption error.
+    ///
+    /// Only one `CorruptKind` variant is tested, the focus of the test
+    /// is the formatting of the nested error type:
+    /// `Ext4Error::Corrupt(Corrupt(CorruptKind))`
+    #[test]
+    fn test_corrupt_format() {
+        let err: Ext4Error = CorruptKind::BlockRead {
+            block_index: 123,
+            offset_within_block: 456,
+            read_len: 789,
+        }
+        .into();
+
+        assert_eq!(
+            format!("{err}"),
+            "corrupt: invalid read of length 789 from block 123 at offset 456"
+        );
+
+        assert_eq!(
+            format!("{err:?}"),
+            "Corrupt(Corrupt(BlockRead { block_index: 123, offset_within_block: 456, read_len: 789 }))"
+        );
+    }
+}


### PR DESCRIPTION
* For `Corrupt`/`Incompatible` errors, change the `Display` impl to say "corrupt filesystem"/"incompatible filesystem" so the error is clearer when printed in isolation
* Make the `Debug` impl for `Corrupt` pass through to the inner `CorruptKind`. This shortens the output from, e.g., `Corrupt(Corrupt(BlockRead { .. }))` to `Corrupt(BlockRead { .. })`.
* Add a test.