### PR TITLE
Remove Ext4Error::as_corrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Removed `Ext4Error::as_corrupt`.
+
 ## 0.8.0
 
 * Added `Path::to_str` and `PathBuf::to_str`.

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -490,11 +490,10 @@ mod tests {
         assert_eq!(len, 72);
 
         // Error: not enough data.
-        let err = DirEntry::from_bytes(fs.clone(), &[], inode1, path.clone())
-            .unwrap_err();
         assert_eq!(
-            *err.as_corrupt().unwrap(),
-            CorruptKind::DirEntry(inode1).into()
+            DirEntry::from_bytes(fs.clone(), &[], inode1, path.clone())
+                .unwrap_err(),
+            CorruptKind::DirEntry(inode1)
         );
 
         // Error: not enough data for the name.

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,16 +87,6 @@ pub enum Ext4Error {
 }
 
 impl Ext4Error {
-    /// If the error type is [`Ext4Error::Corrupt`], get the underlying error.
-    #[must_use]
-    pub fn as_corrupt(&self) -> Option<&Corrupt> {
-        if let Self::Corrupt(err) = self {
-            Some(err)
-        } else {
-            None
-        }
-    }
-
     /// If the error type is [`Ext4Error::Incompatible`], get the underlying error.
     #[must_use]
     pub fn as_incompatible(&self) -> Option<&Incompatible> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,11 +670,8 @@ mod tests {
         data.extend(include_bytes!("../test_data/not_ext4.bin"));
 
         assert_eq!(
-            *Ext4::load(Box::new(data))
-                .unwrap_err()
-                .as_corrupt()
-                .unwrap(),
-            CorruptKind::InvalidBlockSize.into()
+            Ext4::load(Box::new(data)).unwrap_err(),
+            CorruptKind::InvalidBlockSize
         );
     }
 
@@ -682,13 +679,12 @@ mod tests {
         block_index: u64,
         offset_within_block: u32,
         read_len: usize,
-    ) -> Corrupt {
+    ) -> CorruptKind {
         CorruptKind::BlockRead {
             block_index,
             offset_within_block,
             read_len,
         }
-        .into()
     }
 
     /// Test that reading from the first 1024 bytes of the file fails.
@@ -697,11 +693,8 @@ mod tests {
         let fs = load_test_disk1();
         let mut dst = vec![0; 1];
         assert_eq!(
-            fs.read_from_block(0, 1023, &mut dst)
-                .unwrap_err()
-                .as_corrupt()
-                .unwrap(),
-            &block_read_error(0, 1023, 1),
+            fs.read_from_block(0, 1023, &mut dst).unwrap_err(),
+            block_read_error(0, 1023, 1),
         );
     }
 
@@ -711,11 +704,8 @@ mod tests {
         let fs = load_test_disk1();
         let mut dst = vec![0; 1024];
         assert_eq!(
-            fs.read_from_block(999_999_999, 0, &mut dst)
-                .unwrap_err()
-                .as_corrupt()
-                .unwrap(),
-            &block_read_error(999_999_999, 0, 1024),
+            fs.read_from_block(999_999_999, 0, &mut dst).unwrap_err(),
+            block_read_error(999_999_999, 0, 1024),
         );
     }
 
@@ -725,11 +715,8 @@ mod tests {
         let fs = load_test_disk1();
         let mut dst = vec![0; 1024];
         assert_eq!(
-            fs.read_from_block(1, 1024, &mut dst)
-                .unwrap_err()
-                .as_corrupt()
-                .unwrap(),
-            &block_read_error(1, 1024, 1024),
+            fs.read_from_block(1, 1024, &mut dst).unwrap_err(),
+            block_read_error(1, 1024, 1024),
         );
     }
 
@@ -739,11 +726,8 @@ mod tests {
         let fs = load_test_disk1();
         let mut dst = vec![0; 25];
         assert_eq!(
-            fs.read_from_block(1, 1000, &mut dst)
-                .unwrap_err()
-                .as_corrupt()
-                .unwrap(),
-            &block_read_error(1, 1000, 25),
+            fs.read_from_block(1, 1000, &mut dst).unwrap_err(),
+            block_read_error(1, 1000, 25),
         );
     }
 


### PR DESCRIPTION
The internal uses have been removed, and it's not useful as a public method since the `Corrupt` type was made opaque.