### PR TITLE
Update a superblock test to not rely on RECOVERY being unsupported

### DIFF
--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -394,10 +394,12 @@ mod tests {
 
         assert_eq!(
             check_incompat_features(
-                required | IncompatibleFeatures::RECOVERY.bits()
+                required | IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE.bits()
             )
             .unwrap_err(),
-            Incompatible::UnsupportedFeatures(IncompatibleFeatures::RECOVERY)
+            Incompatible::UnsupportedFeatures(
+                IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE
+            )
         );
     }
 }


### PR DESCRIPTION
This is in preparation for the journal work landing, at which point RECOVERY will be a supported feature.

https://github.com/nicholasbishop/ext4-view-rs/issues/317