### PR TITLE
Replace `Incompatible::DirectoryEncrypted` with `Ext4Error::Encrypted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Renamed `Incompatible::Incompatible` to `Incompatible::UnsupportedFeatures`.
 * Removed `Incompatible::Unknown`; these errors are now reported as
   `Incompatible::UnsupportedFeatures`.
+* Removed `Incompatible::DirectoryEncrypted` and replaced it with
+  `Ext4Error::Encrypted`.
 
 ## 0.8.0
 

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -8,7 +8,7 @@
 
 use crate::dir_entry::DirEntryName;
 use crate::dir_htree::get_dir_entry_via_htree;
-use crate::error::{Ext4Error, Incompatible};
+use crate::error::Ext4Error;
 use crate::inode::{Inode, InodeFlags};
 use crate::iters::read_dir::ReadDir;
 use crate::path::PathBuf;
@@ -25,9 +25,7 @@ pub(crate) fn get_dir_entry_inode_by_name(
     assert!(dir_inode.metadata.is_dir());
 
     if dir_inode.flags.contains(InodeFlags::DIRECTORY_ENCRYPTED) {
-        return Err(
-            Incompatible::DirectoryEncrypted(dir_inode.index.get()).into()
-        );
+        return Err(Ext4Error::Encrypted);
     }
 
     if dir_inode.flags.contains(InodeFlags::DIRECTORY_HTREE) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,6 +66,14 @@ pub enum Ext4Error {
     /// of symbolic links.
     TooManySymlinks,
 
+    /// Attempted to read an encrypted file.
+    ///
+    /// Only unencrypted files are currently supported. Please file an
+    /// [issue] if you have a use case for reading encrypted files.
+    ///
+    /// [issue]: https://github.com/nicholasbishop/ext4-view-rs/issues/new
+    Encrypted,
+
     /// An IO operation failed. This error comes from the [`Ext4Read`]
     /// passed to [`Ext4::load`].
     ///
@@ -126,6 +134,7 @@ impl Display for Ext4Error {
             Self::TooManySymlinks => {
                 write!(f, "too many levels of symbolic links")
             }
+            Self::Encrypted => write!(f, "file is encrypted"),
             // TODO: if the `Error` trait ever makes it into core, stop
             // printing `err` here and return it via `Error::source` instead.
             Self::Io(err) => write!(f, "io error: {err}"),
@@ -160,6 +169,7 @@ impl From<Ext4Error> for std::io::Error {
             Ext4Error::Io(inner) => Self::other(inner),
             Ext4Error::NotFound => NotFound.into(),
             Ext4Error::NotUtf8 => InvalidData.into(),
+            Ext4Error::Encrypted => PermissionDenied.into(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -440,13 +440,6 @@ pub enum Incompatible {
         u8,
     ),
 
-    /// Attempted to read an encrypted directory. Only unencrypted
-    /// directories are currently supported.
-    DirectoryEncrypted(
-        /// Inode number.
-        u32,
-    ),
-
     /// The journal superblock type is not supported.
     JournalSuperblockType(
         /// Raw journal block type.
@@ -484,9 +477,6 @@ impl Display for Incompatible {
             }
             Self::DirectoryHash(algorithm) => {
                 write!(f, "unsupported directory hash algorithm: {algorithm}")
-            }
-            Self::DirectoryEncrypted(inode) => {
-                write!(f, "directory in inode {inode} is encrypted")
             }
             Self::JournalSuperblockType(val) => {
                 write!(f, "journal superblock type is not supported: {val}")

--- a/src/iters/read_dir.rs
+++ b/src/iters/read_dir.rs
@@ -9,7 +9,7 @@
 use crate::checksum::Checksum;
 use crate::dir_block::DirBlock;
 use crate::dir_entry::DirEntry;
-use crate::error::{CorruptKind, Ext4Error, Incompatible};
+use crate::error::{CorruptKind, Ext4Error};
 use crate::inode::{Inode, InodeFlags, InodeIndex};
 use crate::iters::file_blocks::FileBlocks;
 use crate::path::PathBuf;
@@ -72,9 +72,7 @@ impl ReadDir {
         let has_htree = inode.flags.contains(InodeFlags::DIRECTORY_HTREE);
 
         if inode.flags.contains(InodeFlags::DIRECTORY_ENCRYPTED) {
-            return Err(Ext4Error::Incompatible(
-                Incompatible::DirectoryEncrypted(inode.index.get()),
-            ));
+            return Err(Ext4Error::Encrypted);
         }
 
         Ok(Self {

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -8,7 +8,7 @@
 
 use crate::expected_holes_data;
 use crate::test_util::load_test_disk1;
-use ext4_view::{Ext4Error, Incompatible, Path, PathBuf};
+use ext4_view::{Ext4Error, Path, PathBuf};
 
 #[cfg(feature = "std")]
 use ext4_view::Ext4;
@@ -386,12 +386,12 @@ fn test_encrypted_dir() {
     // This covers the check in `get_dir_entry_inode_by_name`.
     assert!(matches!(
         fs.read("/encrypted_dir/file").unwrap_err(),
-        Ext4Error::Incompatible(Incompatible::DirectoryEncrypted(_))
+        Ext4Error::Encrypted
     ));
 
     // This covers the check in `ReadDir::new`.
     assert!(matches!(
         fs.read_dir("/encrypted_dir").unwrap_err(),
-        Ext4Error::Incompatible(Incompatible::DirectoryEncrypted(_))
+        Ext4Error::Encrypted
     ));
 }

--- a/xtask/src/diff_walk.rs
+++ b/xtask/src/diff_walk.rs
@@ -8,7 +8,7 @@
 
 use crate::{capture_cmd, run_cmd, sudo};
 use anyhow::{bail, Result};
-use ext4_view::{Ext4, Ext4Error, Incompatible};
+use ext4_view::{Ext4, Ext4Error};
 use sha2::{Digest, Sha256};
 use std::fs::File;
 use std::io::Read;
@@ -112,7 +112,7 @@ fn walk_with_lib(
 
     let entry_iter = match fs.read_dir(path) {
         Ok(entry_iter) => entry_iter,
-        Err(Ext4Error::Incompatible(Incompatible::DirectoryEncrypted(_))) => {
+        Err(Ext4Error::Encrypted) => {
             output[0].content = FileContent::EncryptedDir;
             return Ok(output);
         }


### PR DESCRIPTION
Reasons for moving this from `Incompatible` to a top-level error:
    
1. The other errors in `Incompatible` prevent the filesystem from being loaded. However, the lack of support for encrypted directories just prevents those specific paths from being loaded. So any other `Incompatible` error is essentially fatal, but `Incompatible::DirectoryEncrypted` can be handled.
2. If, in the future, support for reading encrypted directories is added, we'll still need an error in case the right encryption key isn't loaded.
    
The new error is named `Encrypted` instead of `DirectoryEncrypted` because although ext4 encryption is directory based, files within a directory can of course be encrypted too, so a more general name is appropriate.

https://github.com/nicholasbishop/ext4-view-rs/issues/389