### PR TITLE
Minor corrupt error cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   `Incompatible::UnsupportedFeatures`.
 * Removed `Incompatible::DirectoryEncrypted` and replaced it with
   `Ext4Error::Encrypted`.
+* Removed `impl From<Corrupt> for Ext4Error`.
 
 ## 0.8.0
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -392,12 +392,6 @@ impl PartialEq<Incompatible> for Ext4Error {
     }
 }
 
-impl From<CorruptKind> for Corrupt {
-    fn from(c: CorruptKind) -> Self {
-        Self(c)
-    }
-}
-
 impl From<CorruptKind> for Ext4Error {
     fn from(c: CorruptKind) -> Self {
         Self::Corrupt(Corrupt(c))

--- a/src/error.rs
+++ b/src/error.rs
@@ -392,12 +392,6 @@ impl PartialEq<Incompatible> for Ext4Error {
     }
 }
 
-impl From<Corrupt> for Ext4Error {
-    fn from(c: Corrupt) -> Self {
-        Self::Corrupt(c)
-    }
-}
-
 impl From<CorruptKind> for Corrupt {
     fn from(c: CorruptKind) -> Self {
         Self(c)

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -161,9 +161,7 @@ impl Inode {
             .div_ceil(ext4.0.superblock.block_size.to_u64())
             // Ext4 allows at most `2^32` blocks in a file.
             .try_into()
-            .map_err(|_| {
-                Ext4Error::Corrupt(CorruptKind::TooManyBlocksInFile.into())
-            })?;
+            .map_err(|_| CorruptKind::TooManyBlocksInFile)?;
 
         Ok((
             Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,14 +296,11 @@ impl Ext4 {
         dst: &mut [u8],
     ) -> Result<(), Ext4Error> {
         let err = || {
-            Ext4Error::Corrupt(
-                CorruptKind::BlockRead {
-                    block_index,
-                    offset_within_block,
-                    read_len: dst.len(),
-                }
-                .into(),
-            )
+            Ext4Error::from(CorruptKind::BlockRead {
+                block_index,
+                offset_within_block,
+                read_len: dst.len(),
+            })
         };
 
         // The first 1024 bytes are reserved for non-filesystem


### PR DESCRIPTION
Simplify some internal error type conversions, and drop `impl From<Corrupt> for Ext4Error`/`impl From<CorruptKind> for Corrupt`.