### PR TITLE
Make `Incompatible` an opaque error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 ## Unreleased
 
-* Removed `Ext4Error::as_corrupt`.
+* Removed `Ext4Error::as_corrupt` and `Ext4Error::as_incompatible`.
 * Renamed `Incompatible::Missing` to `Incompatible::MissingRequiredFeatures`.
 * Renamed `Incompatible::Incompatible` to `Incompatible::UnsupportedFeatures`.
 * Removed `Incompatible::Unknown`; these errors are now reported as
   `Incompatible::UnsupportedFeatures`.
 * Removed `Incompatible::DirectoryEncrypted` and replaced it with
   `Ext4Error::Encrypted`.
-* Removed `impl From<Corrupt> for Ext4Error`.
+* Removed `impl From<Corrupt> for Ext4Error` and
+  `impl From<Incompatible>> for Ext4Error`.
+* Made the `Incompatible` type opaque. It is no longer possible to
+  `match` on specific types of incompatibility.
 
 ## 0.8.0
 

--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -9,7 +9,7 @@
 use crate::dir_block::DirBlock;
 use crate::dir_entry::{DirEntry, DirEntryName};
 use crate::dir_entry_hash::dir_hash_md4_half;
-use crate::error::{CorruptKind, Ext4Error, Incompatible};
+use crate::error::{CorruptKind, Ext4Error, IncompatibleKind};
 use crate::extent::Extent;
 use crate::inode::{Inode, InodeFlags, InodeIndex};
 use crate::iters::extents::Extents;
@@ -287,7 +287,7 @@ fn find_leaf_node(
     // the "half MD4" algorithm is supported by this library.
     let hash_type = block[0x1c];
     if hash_type != 1 {
-        return Err(Incompatible::DirectoryHash(hash_type).into());
+        return Err(IncompatibleKind::DirectoryHash(hash_type).into());
     }
 
     // Read the htree's depth from the root block. The depth is the

--- a/src/error.rs
+++ b/src/error.rs
@@ -404,6 +404,10 @@ impl From<Incompatible> for Ext4Error {
     }
 }
 
+// TODO: temporary alias.
+#[allow(unused)]
+pub(crate) type IncompatibleKind = Incompatible;
+
 /// Error type used in [`Ext4Error::Incompatible`] when the filesystem
 /// cannot be read due to incomplete support in this library.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -95,16 +95,6 @@ pub enum Ext4Error {
 }
 
 impl Ext4Error {
-    /// If the error type is [`Ext4Error::Incompatible`], get the underlying error.
-    #[must_use]
-    pub fn as_incompatible(&self) -> Option<&Incompatible> {
-        if let Self::Incompatible(err) = self {
-            Some(err)
-        } else {
-            None
-        }
-    }
-
     /// If the error type is [`Ext4Error::Io`], get the underlying error.
     #[must_use]
     pub fn as_io(&self) -> Option<&(dyn Error + Send + Sync + 'static)> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -515,4 +515,21 @@ mod tests {
             "Corrupt(BlockRead { block_index: 123, offset_within_block: 456, read_len: 789 })"
         );
     }
+
+    /// Test the `Display` and `Debug` impls for an `Incompatible` error.
+    ///
+    /// Only one `IncompatibleKind` variant is tested, the focus of the test
+    /// is the formatting of the nested error type:
+    /// `Ext4Error::Incompatible(Incompatible(IncompatibleKind))`
+    #[test]
+    fn test_incompatible_format() {
+        let err: Ext4Error = IncompatibleKind::DirectoryHash(123).into();
+
+        assert_eq!(
+            format!("{err}"),
+            "incompatible filesystem: unsupported directory hash algorithm: 123"
+        );
+
+        assert_eq!(format!("{err:?}"), "Incompatible(DirectoryHash(123))");
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -382,37 +382,32 @@ impl PartialEq<CorruptKind> for Ext4Error {
     }
 }
 
-impl PartialEq<Incompatible> for Ext4Error {
-    fn eq(&self, other: &Incompatible) -> bool {
-        if let Self::Incompatible(i) = self {
-            i == other
-        } else {
-            false
-        }
-    }
-}
-
 impl From<CorruptKind> for Ext4Error {
     fn from(c: CorruptKind) -> Self {
         Self::Corrupt(Corrupt(c))
     }
 }
 
-impl From<Incompatible> for Ext4Error {
-    fn from(i: Incompatible) -> Self {
-        Self::Incompatible(i)
+/// Error type used in [`Ext4Error::Incompatible`] when the filesystem
+/// cannot be read due to incomplete support in this library.
+#[derive(Clone, Eq, PartialEq)]
+pub struct Incompatible(IncompatibleKind);
+
+impl Debug for Incompatible {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        <IncompatibleKind as Debug>::fmt(&self.0, f)
     }
 }
 
-// TODO: temporary alias.
-#[allow(unused)]
-pub(crate) type IncompatibleKind = Incompatible;
+impl Display for Incompatible {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        <IncompatibleKind as Display>::fmt(&self.0, f)
+    }
+}
 
-/// Error type used in [`Ext4Error::Incompatible`] when the filesystem
-/// cannot be read due to incomplete support in this library.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum Incompatible {
+pub(crate) enum IncompatibleKind {
     /// One or more required features are missing.
     MissingRequiredFeatures(
         /// The missing features.
@@ -458,7 +453,7 @@ pub enum Incompatible {
     ),
 }
 
-impl Display for Incompatible {
+impl Display for IncompatibleKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::MissingRequiredFeatures(feat) => {
@@ -483,6 +478,22 @@ impl Display for Incompatible {
                 write!(f, "unsupported journal features: {feat:?}")
             }
         }
+    }
+}
+
+impl PartialEq<IncompatibleKind> for Ext4Error {
+    fn eq(&self, other: &IncompatibleKind) -> bool {
+        if let Self::Incompatible(Incompatible(i)) = self {
+            i == other
+        } else {
+            false
+        }
+    }
+}
+
+impl From<IncompatibleKind> for Ext4Error {
+    fn from(k: IncompatibleKind) -> Self {
+        Self::Incompatible(Incompatible(k))
     }
 }
 


### PR DESCRIPTION
Essentially the same transformation as was previously applied to `Corrupt`. This reduces the API surface of the library, while still providing a reasonable amount of error detail through `Debug`/`Display`.

https://github.com/nicholasbishop/ext4-view-rs/issues/389