### PR TITLE
Add DescriptorBlockTagIter

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -232,6 +232,12 @@ pub(crate) enum CorruptKind {
     /// Journal superblock checksum is invalid.
     JournalSuperblockChecksum,
 
+    /// Journal has a truncated descriptor block. Either it is missing a
+    /// tag with the `LAST_TAG` flag set, or the final tag does have
+    /// that flag set but there are not enough bytes to read the full
+    /// tag.
+    JournalDescriptorBlockTruncated,
+
     /// An inode's checksum is invalid.
     InodeChecksum(InodeIndex),
 
@@ -314,6 +320,9 @@ impl Display for CorruptKind {
             }
             Self::JournalSuperblockChecksum => {
                 write!(f, "journal superblock checksum is invalid")
+            }
+            Self::JournalDescriptorBlockTruncated => {
+                write!(f, "journal descriptor block is truncated")
             }
             Self::InodeChecksum(inode) => {
                 write!(f, "invalid checksum for inode {inode}")

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -8,7 +8,7 @@
 
 #[expect(unused)] // TODO
 mod block_header;
-#[expect(unused)] // TODO
+#[allow(unused)] // TODO
 mod descriptor_block;
 #[expect(unused)] // TODO
 mod superblock;


### PR DESCRIPTION
This produces tags from the raw bytes of a journal descriptor block.

(Changed `expect(unused)` to `allow` because under `cargo test` the code is no longer unused.)

https://github.com/nicholasbishop/ext4-view-rs/issues/317