### PR TITLE
Ignore the journal if the RECOVERY bit is not set

### DIFF
--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -121,22 +121,24 @@ impl Superblock {
             return Err(CorruptKind::InodeSize.into());
         }
 
-        let journal_inode =
-            if compatible_features.contains(CompatibleFeatures::HAS_JOURNAL) {
-                // For now a separate journal device is not supported, so
-                // assert that feature is not present. This assert cannot
-                // fail because of the call to `check_incompat_features`
-                // above.
-                assert!(!incompatible_features
-                    .contains(IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE));
+        let journal_inode = if compatible_features
+            .contains(CompatibleFeatures::HAS_JOURNAL)
+            && incompatible_features.contains(IncompatibleFeatures::RECOVERY)
+        {
+            // For now a separate journal device is not supported, so
+            // assert that feature is not present. This assert cannot
+            // fail because of the call to `check_incompat_features`
+            // above.
+            assert!(!incompatible_features
+                .contains(IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE));
 
-                Some(
-                    InodeIndex::new(s_journal_inum)
-                        .ok_or(CorruptKind::JournalInode)?,
-                )
-            } else {
-                None
-            };
+            Some(
+                InodeIndex::new(s_journal_inum)
+                    .ok_or(CorruptKind::JournalInode)?,
+            )
+        } else {
+            None
+        };
 
         // Validate the superblock checksum.
         if read_only_compatible_features


### PR DESCRIPTION
Rustfmt makes this look like a bigger change than it is, only the condition is being modified.

Note that this has no immediate effect, since for now the RECOVERY bit is still in the set of disallowed features.

https://github.com/nicholasbishop/ext4-view-rs/issues/317