### PR TITLE
Check for escaped journal data blocks

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -456,6 +456,9 @@ pub(crate) enum IncompatibleKind {
         /// The unsupported feature bits.
         u32,
     ),
+
+    /// The journal contains an escaped block.
+    JournalBlockEscaped,
 }
 
 impl Display for IncompatibleKind {
@@ -472,6 +475,9 @@ impl Display for IncompatibleKind {
             }
             Self::JournalSuperblockType(val) => {
                 write!(f, "journal superblock type is not supported: {val}")
+            }
+            Self::JournalBlockEscaped => {
+                write!(f, "journal contains an escaped data block")
             }
             Self::JournalChecksumType(val) => {
                 write!(f, "journal checksum type is not supported: {val}")


### PR DESCRIPTION
An escaped tag indicates that a data block happens to start with the magic bytes used to identify journal blocks. The data block as stored on disk will have those bytes zeroed, but when replaying the journal those bytes should be restored.

This is unlikely to come up in practice, and will take some extra work to support (and add tests for), so disallow it for now.

https://github.com/nicholasbishop/ext4-view-rs/issues/317