### PR TITLE
Add several path conversions on non-Unix targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
   `impl From<Incompatible>> for Ext4Error`.
 * Made the `Incompatible` type opaque. It is no longer possible to
   `match` on specific types of incompatibility.
+* Implemented several path conversions for non-Unix platforms that were
+  previously only available on Unix. On non-Unix platforms, these
+  conversions will fail on non-UTF-8 input.
+  * `TryFrom<&OsStr> for ext4_view::Path`
+  * `TryFrom<&std::path::PathBuf> for ext4_view::Path`
+  * `TryFrom<OsString> for ext4_view::PathBuf`
+  * `TryFrom<std::path::PathBuf> for ext4_view::PathBuf`
 
 ## 0.8.0
 

--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -12,7 +12,6 @@
 
 use anyhow::{Context, Result};
 use ext4_view::Ext4;
-use std::ffi::OsString;
 use std::io::{self, ErrorKind, Read, Write};
 use std::{env, process};
 
@@ -36,7 +35,8 @@ fn parse_args() -> Result<(std::path::PathBuf, ext4_view::PathBuf)> {
     }
 
     let filesystem = std::path::PathBuf::from(&args[1]);
-    let path = get_ext4_path(args[2].clone())?;
+    let path = ext4_view::PathBuf::try_from(args[2].clone())
+        .context("Invalid ext4 path")?;
 
     Ok((filesystem, path))
 }
@@ -81,13 +81,4 @@ fn main() -> Result<()> {
             }
         }
     }
-}
-
-fn get_ext4_path(s: OsString) -> Result<ext4_view::PathBuf> {
-    // TODO: implement a better conversion on Windows.
-    // https://github.com/nicholasbishop/ext4-view-rs/issues/361
-    #[cfg(windows)]
-    let s = s.to_str().context("Path is not UTF-8")?;
-
-    ext4_view::PathBuf::try_from(s).context("Invalid ext4 path")
 }


### PR DESCRIPTION
This change allows constructing `ext4_view::Path` and `ext4_view::PathBuf` from `OsStr`/`OsString`/`std::path::Path`/`std::path::PathBuf`, as long as the input is UTF-8.

This PR supercedes https://github.com/nicholasbishop/ext4-view-rs/pull/381.

These conversions are more restrictive than on Unix, where the input is not required to be UTF-8, but should adequately cover common usage. It is already possible to construct `ext4_view` paths from raw bytes if more control is needed.
    
Note: the error tests in `tests/integration/path.rs` are gated on `windows` because we need `std::os::windows::ffi::OsStringExt` to construct the invalid input data. However, the actual conversion implementations don't need any special API and are more general: `not(unix)` rather than `windows`.

Also simplified the code in `examples/cat.rs`.

Closes https://github.com/nicholasbishop/ext4-view-rs/issues/361