### PR TITLE
Update Rust style to 2024 edition

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,2 @@
 max_width = 80
+style_edition = "2024"

--- a/src/block_group.rs
+++ b/src/block_group.rs
@@ -6,12 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4Read;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::features::{IncompatibleFeatures, ReadOnlyCompatibleFeatures};
 use crate::superblock::Superblock;
 use crate::util::{read_u16le, read_u32le, u64_from_hilo, usize_from_u32};
-use crate::Ext4Read;
 use alloc::vec;
 use alloc::vec::Vec;
 

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -6,13 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::dir_entry::DirEntryName;
 use crate::dir_htree::get_dir_entry_via_htree;
 use crate::error::Ext4Error;
 use crate::inode::{Inode, InodeFlags};
 use crate::iters::read_dir::ReadDir;
 use crate::path::PathBuf;
-use crate::Ext4;
 
 /// Search a directory inode for an entry with the given `name`. If
 /// found, return the entry's inode, otherwise return a `NotFound`

--- a/src/dir_block.rs
+++ b/src/dir_block.rs
@@ -6,11 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::inode::InodeIndex;
 use crate::util::{read_u16le, read_u32le};
-use crate::Ext4;
 
 #[derive(Debug, Eq, PartialEq)]
 enum DirBlockType {

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -6,14 +6,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::file_type::FileType;
-use crate::format::{format_bytes_debug, BytesDisplay};
+use crate::format::{BytesDisplay, format_bytes_debug};
 use crate::inode::{Inode, InodeIndex};
 use crate::metadata::Metadata;
 use crate::path::{Path, PathBuf};
 use crate::util::{read_u16le, read_u32le};
-use crate::Ext4;
 use alloc::rc::Rc;
 use core::error::Error;
 use core::fmt::{self, Debug, Display, Formatter};
@@ -516,7 +516,9 @@ mod tests {
         bytes.push(8u8); // file type
         bytes.extend("ab/".bytes()); // name
         bytes.resize(72, 0u8);
-        assert!(DirEntry::from_bytes(fs.clone(), &bytes, inode1, path).is_err());
+        assert!(
+            DirEntry::from_bytes(fs.clone(), &bytes, inode1, path).is_err()
+        );
     }
 
     #[test]

--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::dir_block::DirBlock;
 use crate::dir_entry::{DirEntry, DirEntryName};
 use crate::dir_entry_hash::dir_hash_md4_half;
@@ -16,7 +17,6 @@ use crate::iters::extents::Extents;
 use crate::iters::file_blocks::FileBlocks;
 use crate::path::PathBuf;
 use crate::util::{read_u16le, read_u32le, usize_from_u32};
-use crate::Ext4;
 use alloc::rc::Rc;
 use alloc::vec;
 
@@ -495,14 +495,16 @@ mod tests {
         assert_eq!(entry.file_name(), "..");
 
         // Check that an arbitrary name returns `None`.
-        assert!(read_dot_or_dotdot(
-            fs.clone(),
-            &inode,
-            "somename".try_into().unwrap(),
-            &block
-        )
-        .unwrap()
-        .is_none());
+        assert!(
+            read_dot_or_dotdot(
+                fs.clone(),
+                &inode,
+                "somename".try_into().unwrap(),
+                &block
+            )
+            .unwrap()
+            .is_none()
+        );
     }
 
     /// Use ReadDir to iterate over all directory entries. Check that

--- a/src/error.rs
+++ b/src/error.rs
@@ -405,7 +405,10 @@ impl Display for CorruptKind {
                 block_group,
                 num_block_groups,
             } => {
-                write!(f, "inode {inode} has an invalid block group index: block_group={block_group}, num_block_groups={num_block_groups}")
+                write!(
+                    f,
+                    "inode {inode} has an invalid block group index: block_group={block_group}, num_block_groups={num_block_groups}"
+                )
             }
             Self::InodeLocation {
                 inode,
@@ -415,7 +418,10 @@ impl Display for CorruptKind {
                 block_size,
                 inode_table_first_block,
             } => {
-                write!(f, "inode {inode} has invalid location: block_group={block_group}, inodes_per_block_group={inodes_per_block_group}, inode_size={inode_size}, block_size={block_size}, inode_table_first_block={inode_table_first_block}")
+                write!(
+                    f,
+                    "inode {inode} has invalid location: block_group={block_group}, inodes_per_block_group={inodes_per_block_group}, inode_size={inode_size}, block_size={block_size}, inode_table_first_block={inode_table_first_block}"
+                )
             }
             Self::InodeFileType { inode, mode } => {
                 write!(
@@ -461,7 +467,10 @@ impl Display for CorruptKind {
                 offset_within_block,
                 read_len,
             } => {
-                write!(f, "invalid read of length {read_len} from block {block_index} at offset {offset_within_block}")
+                write!(
+                    f,
+                    "invalid read of length {read_len} from block {block_index} at offset {offset_within_block}"
+                )
             }
         }
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::error::Ext4Error;
 use crate::inode::Inode;
 use crate::iters::file_blocks::FileBlocks;
@@ -13,7 +14,6 @@ use crate::metadata::Metadata;
 use crate::path::Path;
 use crate::resolve::FollowSymlinks;
 use crate::util::usize_from_u32;
-use crate::Ext4;
 use core::fmt::{self, Debug, Formatter};
 
 #[cfg(feature = "std")]

--- a/src/file_type.rs
+++ b/src/file_type.rs
@@ -128,23 +128,31 @@ mod tests {
     fn test_file_type() {
         // Check each valid file type.
         assert!(FileType::try_from(InodeMode::S_IFIFO).unwrap().is_fifo());
-        assert!(FileType::try_from(InodeMode::S_IFCHR)
-            .unwrap()
-            .is_char_dev());
-        assert!(FileType::try_from(InodeMode::S_IFBLK)
-            .unwrap()
-            .is_block_dev());
-        assert!(FileType::try_from(InodeMode::S_IFREG)
-            .unwrap()
-            .is_regular_file());
+        assert!(
+            FileType::try_from(InodeMode::S_IFCHR)
+                .unwrap()
+                .is_char_dev()
+        );
+        assert!(
+            FileType::try_from(InodeMode::S_IFBLK)
+                .unwrap()
+                .is_block_dev()
+        );
+        assert!(
+            FileType::try_from(InodeMode::S_IFREG)
+                .unwrap()
+                .is_regular_file()
+        );
         assert!(FileType::try_from(InodeMode::S_IFLNK).unwrap().is_symlink());
         assert!(FileType::try_from(InodeMode::S_IFSOCK).unwrap().is_socket());
 
         // Check that other bits being set in the mode don't impact the
         // file type.
-        assert!(FileType::try_from(InodeMode::S_IFREG | InodeMode::S_IXOTH)
-            .unwrap()
-            .is_regular_file());
+        assert!(
+            FileType::try_from(InodeMode::S_IFREG | InodeMode::S_IXOTH)
+                .unwrap()
+                .is_regular_file()
+        );
 
         // Error, no file type set.
         assert_eq!(

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::file_type::FileType;
@@ -14,7 +15,6 @@ use crate::path::PathBuf;
 use crate::util::{
     read_u16le, read_u32le, u32_from_hilo, u64_from_hilo, usize_from_u32,
 };
-use crate::Ext4;
 use alloc::vec;
 use bitflags::bitflags;
 use core::num::NonZeroU32;

--- a/src/iters/extents.rs
+++ b/src/iters/extents.rs
@@ -6,12 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::extent::Extent;
 use crate::inode::{Inode, InodeIndex};
 use crate::util::{read_u16le, read_u32le, u64_from_hilo, usize_from_u32};
-use crate::Ext4;
 use alloc::vec;
 use alloc::vec::Vec;
 

--- a/src/iters/file_blocks/extents_blocks.rs
+++ b/src/iters/file_blocks/extents_blocks.rs
@@ -6,11 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::extent::Extent;
 use crate::inode::{Inode, InodeIndex};
 use crate::iters::extents::Extents;
-use crate::Ext4;
 
 /// Iterator over blocks in a file that uses extents.
 ///

--- a/src/iters/read_dir.rs
+++ b/src/iters/read_dir.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::checksum::Checksum;
 use crate::dir_block::DirBlock;
 use crate::dir_entry::DirEntry;
@@ -13,7 +14,6 @@ use crate::error::{CorruptKind, Ext4Error};
 use crate::inode::{Inode, InodeFlags, InodeIndex};
 use crate::iters::file_blocks::FileBlocks;
 use crate::path::PathBuf;
-use crate::Ext4;
 use alloc::rc::Rc;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -12,10 +12,10 @@ mod commit_block;
 mod descriptor_block;
 mod superblock;
 
+use crate::Ext4;
 use crate::error::Ext4Error;
 use crate::inode::Inode;
-use crate::Ext4;
-use block_map::{load_block_map, BlockMap};
+use block_map::{BlockMap, load_block_map};
 use superblock::JournalSuperblock;
 
 #[derive(Debug)]

--- a/src/journal/block_map.rs
+++ b/src/journal/block_map.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error, IncompatibleKind};
 use crate::inode::Inode;
@@ -13,11 +14,10 @@ use crate::iters::file_blocks::FileBlocks;
 use crate::journal::block_header::{JournalBlockHeader, JournalBlockType};
 use crate::journal::commit_block::validate_commit_block_checksum;
 use crate::journal::descriptor_block::{
-    validate_descriptor_block_checksum, DescriptorBlockTagIter,
+    DescriptorBlockTagIter, validate_descriptor_block_checksum,
 };
 use crate::journal::superblock::JournalSuperblock;
 use crate::util::usize_from_u32;
-use crate::Ext4;
 use alloc::collections::BTreeMap;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/src/journal/descriptor_block.rs
+++ b/src/journal/descriptor_block.rs
@@ -197,7 +197,9 @@ mod tests {
         );
 
         block[1020..].copy_from_slice(&[0x74, 0xef, 0x0e, 0xf6]);
-        assert!(validate_descriptor_block_checksum(&superblock, &block).is_ok());
+        assert!(
+            validate_descriptor_block_checksum(&superblock, &block).is_ok()
+        );
     }
 
     fn push_u32be(bytes: &mut Vec<u8>, value: u32) {

--- a/src/journal/superblock.rs
+++ b/src/journal/superblock.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::Ext4;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error, IncompatibleKind};
 use crate::inode::Inode;
@@ -13,7 +14,6 @@ use crate::iters::file_blocks::FileBlocks;
 use crate::journal::block_header::{JournalBlockHeader, JournalBlockType};
 use crate::util::read_u32be;
 use crate::uuid::Uuid;
-use crate::Ext4;
 use alloc::vec;
 use bitflags::bitflags;
 

--- a/src/label.rs
+++ b/src/label.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::format::{format_bytes_debug, BytesDisplay};
+use crate::format::{BytesDisplay, format_bytes_debug};
 use core::fmt::{self, Debug, Formatter};
 use core::str::Utf8Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,14 +742,16 @@ mod tests {
         assert_eq!(inode.index.get(), 2);
 
         // Successful lookup.
-        assert!(fs
-            .path_to_inode(Path::try_from("/empty_file").unwrap(), follow)
-            .is_ok());
+        assert!(
+            fs.path_to_inode(Path::try_from("/empty_file").unwrap(), follow)
+                .is_ok()
+        );
 
         // Successful lookup with a "." component.
-        assert!(fs
-            .path_to_inode(Path::try_from("/./empty_file").unwrap(), follow)
-            .is_ok());
+        assert!(
+            fs.path_to_inode(Path::try_from("/./empty_file").unwrap(), follow)
+                .is_ok()
+        );
 
         // Successful lookup with a ".." component.
         let inode = fs
@@ -758,30 +760,34 @@ mod tests {
         assert_eq!(inode.index.get(), 2);
 
         // Successful lookup with symlink.
-        assert!(fs
-            .path_to_inode(Path::try_from("/sym_simple").unwrap(), follow)
-            .is_ok());
+        assert!(
+            fs.path_to_inode(Path::try_from("/sym_simple").unwrap(), follow)
+                .is_ok()
+        );
 
         // Error: not an absolute path.
-        assert!(fs
-            .path_to_inode(Path::try_from("empty_file").unwrap(), follow)
-            .is_err());
+        assert!(
+            fs.path_to_inode(Path::try_from("empty_file").unwrap(), follow)
+                .is_err()
+        );
 
         // Error: invalid child of a valid directory.
-        assert!(fs
-            .path_to_inode(
+        assert!(
+            fs.path_to_inode(
                 Path::try_from("/empty_dir/does_not_exist").unwrap(),
                 follow
             )
-            .is_err());
+            .is_err()
+        );
 
         // Error: attempted to lookup child of a regular file.
-        assert!(fs
-            .path_to_inode(
+        assert!(
+            fs.path_to_inode(
                 Path::try_from("/empty_file/does_not_exist").unwrap(),
                 follow
             )
-            .is_err());
+            .is_err()
+        );
 
         // TODO: add deeper paths to the test disk and test here.
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use crate::dir_entry::{DirEntryName, DirEntryNameError};
-use crate::format::{format_bytes_debug, BytesDisplay};
+use crate::format::{BytesDisplay, format_bytes_debug};
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::error::Error;

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -129,8 +129,10 @@ impl Superblock {
             // assert that feature is not present. This assert cannot
             // fail because of the call to `check_incompat_features`
             // above.
-            assert!(!incompatible_features
-                .contains(IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE));
+            assert!(
+                !incompatible_features
+                    .contains(IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE)
+            );
 
             Some(
                 InodeIndex::new(s_journal_inum)

--- a/xtask/src/big_fs.rs
+++ b/xtask/src/big_fs.rs
@@ -53,7 +53,9 @@ pub fn download_big_filesystems() -> Result<()> {
     let expected_sha256 =
         "9e1b25a4e509c9fccd62d074d963e0fda718ef0e06403e9a0a0804eb90a53b31";
 
-    let url = format!("https://storage.googleapis.com/{bucket}/{board}/{version}/{compressed_file_name}");
+    let url = format!(
+        "https://storage.googleapis.com/{bucket}/{board}/{version}/{compressed_file_name}"
+    );
 
     let download_path = tmp_dir.path().join(compressed_file_name);
     let tar_path = tmp_dir.path().join(tar_file_name);

--- a/xtask/src/bin/mount_and_walk.rs
+++ b/xtask/src/bin/mount_and_walk.rs
@@ -25,7 +25,7 @@
 //! /big_dir/0 644 file sha256=5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9
 //! ```
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use std::ffi::CString;
 use std::io::{self, Write};
 use std::mem::MaybeUninit;
@@ -34,7 +34,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use std::{env, fs};
 use xtask::diff_walk::{FileContent, WalkDirEntry};
-use xtask::{calc_file_sha256, Mount, ReadOnly};
+use xtask::{Mount, ReadOnly, calc_file_sha256};
 
 /// Check if a directory is encrypted or not.
 fn is_encrypted_dir(path: &Path) -> Result<bool> {

--- a/xtask/src/diff_walk.rs
+++ b/xtask/src/diff_walk.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use crate::{capture_cmd, run_cmd, sudo};
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use ext4_view::{Ext4, Ext4Error};
 use sha2::{Digest, Sha256};
 use std::fs::File;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -8,7 +8,7 @@
 
 mod mount;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use sha2::Digest;
 use sha2::Sha256;
 use std::fs::File;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,7 +10,7 @@ mod big_fs;
 mod dmsetup;
 mod losetup;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use dmsetup::{DmDevice, DmFlakey};
 use losetup::LoopDevice;
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, str};
 use tempfile::TempDir;
-use xtask::{capture_cmd, diff_walk, run_cmd, sudo, Mount, ReadOnly};
+use xtask::{Mount, ReadOnly, capture_cmd, diff_walk, run_cmd, sudo};
 
 /// Get the path of the root directory of the repo.
 ///


### PR DESCRIPTION
This style will become the default when we upgrade to the crates to
2024. Setting in the rustfmt config allows us to make the style changes separate from the edition upgrade, and can be useful for editors that use rustfmt directly [0].

The only manual change in this commit is in `.rustfmt.toml`, the rest is the result of `cargo fmt --all`.

[0]: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rustfmt-style-edition.html#migration