### PR TITLE
Improve error and termination handling in the journal `load_block_map` function

### DIFF
--- a/src/journal/block_map.rs
+++ b/src/journal/block_map.rs
@@ -38,10 +38,14 @@ pub(super) fn load_block_map(
     while let Some(block_index) = loader.journal_block_iter.next() {
         loader.block_index = block_index?;
 
-        // If the end of the journal was reached, or an error occurred,
-        // stop reading the journal. Any uncommitted changes are
-        // discarded.
-        if loader.is_done || loader.process_next().is_err() {
+        // If an error occurred, stop reading the journal. Any
+        // uncommitted changes are discarded.
+        if loader.process_next().is_err() {
+            break;
+        }
+
+        // Stop reading if the end of the journal was reached.
+        if loader.is_done {
             break;
         }
     }


### PR DESCRIPTION
* Propagate non-corruption errors when loading the journal block map. In particular, `IncompatibleKind::JournalBlockType` is now fatal, as well as IO errors from reading journal blocks.
* Move the `is_done` check to right after processing a block. We should not continue on to the next iteration of the loop if we've already reached the last journal block.

https://github.com/nicholasbishop/ext4-view-rs/issues/317