### PR TITLE
release: 0.9.0, take two

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rust-version = "1.81"
 include = [
     "src/*.rs",
     "src/iters",
+    "src/journal",
     "LICENSE-APACHE",
     "LICENSE-MIT",
 ]


### PR DESCRIPTION
Add missing source files to the cargo `include` list.