### PR TITLE
Remove unnecessary Result from JournalBlockHeader::read_bytes

### DIFF
--- a/src/journal/block_map.rs
+++ b/src/journal/block_map.rs
@@ -138,7 +138,7 @@ impl<'a> BlockMapLoader<'a> {
         self.fs
             .read_from_block(self.block_index, 0, &mut self.block)?;
 
-        let Some(header) = JournalBlockHeader::read_bytes(&self.block)? else {
+        let Some(header) = JournalBlockHeader::read_bytes(&self.block) else {
             // Journal block magic is not present, so we've reached
             // the end of the journal.
             self.is_done = true;

--- a/src/journal/superblock.rs
+++ b/src/journal/superblock.rs
@@ -98,7 +98,7 @@ impl JournalSuperblock {
     fn read_bytes(bytes: &[u8]) -> Result<Self, Ext4Error> {
         assert_eq!(bytes.len(), SUPERBLOCK_SIZE);
 
-        let header = JournalBlockHeader::read_bytes(bytes)?
+        let header = JournalBlockHeader::read_bytes(bytes)
             .ok_or(CorruptKind::JournalMagic)?;
 
         // For now only superblock v2 is supported.


### PR DESCRIPTION
This function never returned `Err`. The only failure cases are if the magic is missing (which returns None) and if the input is too short (which panics). Document the panic as well.

Fixes https://github.com/nicholasbishop/ext4-view-rs/issues/441