### PR TITLE
Add block index type aliases

### DIFF
--- a/src/block_group.rs
+++ b/src/block_group.rs
@@ -8,6 +8,7 @@
 
 use crate::Ext4Read;
 use crate::checksum::Checksum;
+use crate::block_index::FsBlockIndex;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::features::{IncompatibleFeatures, ReadOnlyCompatibleFeatures};
 use crate::superblock::Superblock;
@@ -19,7 +20,7 @@ pub(crate) type BlockGroupIndex = u32;
 
 #[derive(Debug)]
 pub(crate) struct BlockGroupDescriptor {
-    pub(crate) inode_table_first_block: u64,
+    pub(crate) inode_table_first_block: FsBlockIndex,
     checksum: u16,
 }
 

--- a/src/block_group.rs
+++ b/src/block_group.rs
@@ -7,8 +7,8 @@
 // except according to those terms.
 
 use crate::Ext4Read;
-use crate::checksum::Checksum;
 use crate::block_index::FsBlockIndex;
+use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::features::{IncompatibleFeatures, ReadOnlyCompatibleFeatures};
 use crate::superblock::Superblock;

--- a/src/block_index.rs
+++ b/src/block_index.rs
@@ -1,0 +1,13 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Absolute block index within the filesystem.
+pub(crate) type FsBlockIndex = u64;
+
+/// Block index relative to the start of a file.
+pub(crate) type FileBlockIndex = u32;

--- a/src/dir_block.rs
+++ b/src/dir_block.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use crate::Ext4;
+use crate::block_index::FsBlockIndex;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::inode::InodeIndex;
@@ -31,7 +32,7 @@ pub(crate) struct DirBlock<'a> {
     pub(crate) fs: &'a Ext4,
 
     /// Absolute index of the block within the filesystem.
-    pub(crate) block_index: u64,
+    pub(crate) block_index: FsBlockIndex,
 
     /// Whether this is the first block of the file.
     pub(crate) is_first: bool,

--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use crate::Ext4;
-use crate::block_index::FileBlockIndex;
+use crate::block_index::{FileBlockIndex, FsBlockIndex};
 use crate::dir_block::DirBlock;
 use crate::dir_entry::{DirEntry, DirEntryName};
 use crate::dir_entry_hash::dir_hash_md4_half;
@@ -257,7 +257,7 @@ fn block_from_file_block(
     fs: &Ext4,
     inode: &Inode,
     relative_block: FileBlockIndex,
-) -> Result<u64, Ext4Error> {
+) -> Result<FsBlockIndex, Ext4Error> {
     if inode.flags.contains(InodeFlags::EXTENTS) {
         let extent = find_extent_for_block(fs, inode, relative_block)?;
         let block_within_extent = relative_block

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::block_index::FsBlockIndex;
 use crate::block_size::BlockSize;
 use crate::features::IncompatibleFeatures;
 use crate::inode::{InodeIndex, InodeMode};
@@ -285,7 +286,7 @@ pub(crate) enum CorruptKind {
         inodes_per_block_group: NonZero<u32>,
         inode_size: u16,
         block_size: BlockSize,
-        inode_table_first_block: u64,
+        inode_table_first_block: FsBlockIndex,
     },
 
     /// An inode's file type is invalid.
@@ -325,12 +326,12 @@ pub(crate) enum CorruptKind {
     /// Invalid read of a block.
     BlockRead {
         /// Absolute block index.
-        block_index: u64,
+        block_index: FsBlockIndex,
 
         /// Absolute block index, without remapping from the journal. If
         /// this block was not remapped by the journal, this field will
         /// be the same as `block_index`.
-        original_block_index: u64,
+        original_block_index: FsBlockIndex,
 
         /// Offset in bytes within the block.
         offset_within_block: u32,

--- a/src/extent.rs
+++ b/src/extent.rs
@@ -6,14 +6,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::block_index::{FileBlockIndex, FsBlockIndex};
+
 /// Contiguous range of blocks that contain file data.
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) struct Extent {
     // Offset of the block within the file.
-    pub(crate) block_within_file: u32,
+    pub(crate) block_within_file: FileBlockIndex,
 
     // This is the actual block within the filesystem.
-    pub(crate) start_block: u64,
+    pub(crate) start_block: FsBlockIndex,
 
     // Number of blocks (both within the file, and on the filesystem).
     pub(crate) num_blocks: u16,

--- a/src/file.rs
+++ b/src/file.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use crate::Ext4;
+use crate::block_index::FsBlockIndex;
 use crate::error::Ext4Error;
 use crate::inode::Inode;
 use crate::iters::file_blocks::FileBlocks;
@@ -33,7 +34,7 @@ pub struct File {
     ///
     /// If `None`, either the next block needs to be fetched from the
     /// `file_blocks` iterator, or the end of the file has been reached.
-    block_index: Option<u64>,
+    block_index: Option<FsBlockIndex>,
 }
 
 impl File {

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use crate::Ext4;
+use crate::block_index::FsBlockIndex;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::file_type::FileType;
@@ -287,7 +288,7 @@ impl Inode {
 fn get_inode_location(
     ext4: &Ext4,
     inode: InodeIndex,
-) -> Result<(u64, u32), Ext4Error> {
+) -> Result<(FsBlockIndex, u32), Ext4Error> {
     let sb = &ext4.0.superblock;
 
     // OK to unwrap: `inode` is nonzero.

--- a/src/iters/file_blocks.rs
+++ b/src/iters/file_blocks.rs
@@ -9,6 +9,7 @@
 mod block_map;
 mod extents_blocks;
 
+use crate::block_index::FsBlockIndex;
 use crate::inode::{Inode, InodeFlags};
 use crate::{Ext4, Ext4Error};
 use block_map::BlockMap;
@@ -42,9 +43,9 @@ impl FileBlocks {
 
 impl Iterator for FileBlocks {
     /// Block index.
-    type Item = Result<u64, Ext4Error>;
+    type Item = Result<FsBlockIndex, Ext4Error>;
 
-    fn next(&mut self) -> Option<Result<u64, Ext4Error>> {
+    fn next(&mut self) -> Option<Result<FsBlockIndex, Ext4Error>> {
         match self {
             Self(FileBlocksInner::ExtentsBlocks(iter)) => iter.next(),
             Self(FileBlocksInner::BlockMap(iter)) => iter.next(),

--- a/src/iters/file_blocks/extents_blocks.rs
+++ b/src/iters/file_blocks/extents_blocks.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use crate::Ext4;
+use crate::block_index::{FileBlockIndex, FsBlockIndex};
 use crate::error::{CorruptKind, Ext4Error};
 use crate::extent::Extent;
 use crate::inode::{Inode, InodeIndex};
@@ -33,7 +34,7 @@ pub(super) struct ExtentsBlocks {
 
     /// Current block within the file. This is relative to the file, not
     /// an absolute block index.
-    block_within_file: u32,
+    block_within_file: FileBlockIndex,
 
     /// Total number of blocks in the file.
     num_blocks_total: u32,
@@ -61,7 +62,7 @@ impl ExtentsBlocks {
         })
     }
 
-    fn next_impl(&mut self) -> Result<Option<u64>, Ext4Error> {
+    fn next_impl(&mut self) -> Result<Option<FsBlockIndex>, Ext4Error> {
         if self.block_within_file >= self.num_blocks_total {
             self.is_done = true;
             return Ok(None);
@@ -183,7 +184,7 @@ impl ExtentsBlocks {
 // if hole after last extent {
 //   yield 0 for each block in hole;
 // }
-impl_result_iter!(ExtentsBlocks, u64);
+impl_result_iter!(ExtentsBlocks, FsBlockIndex);
 
 #[cfg(feature = "std")]
 #[cfg(test)]

--- a/src/iters/read_dir.rs
+++ b/src/iters/read_dir.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use crate::Ext4;
+use crate::block_index::FsBlockIndex;
 use crate::checksum::Checksum;
 use crate::dir_block::DirBlock;
 use crate::dir_entry::DirEntry;
@@ -35,7 +36,7 @@ pub struct ReadDir {
 
     /// Current absolute block index, or `None` if the next block needs
     /// to be fetched.
-    block_index: Option<u64>,
+    block_index: Option<FsBlockIndex>,
 
     /// Whether this is the first block in the file.
     is_first_block: bool,

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -13,6 +13,7 @@ mod descriptor_block;
 mod superblock;
 
 use crate::Ext4;
+use crate::block_index::FsBlockIndex;
 use crate::error::Ext4Error;
 use crate::inode::Inode;
 use block_map::{BlockMap, load_block_map};
@@ -55,7 +56,10 @@ impl Journal {
     ///
     /// If the journal does not contain a replacement for the input
     /// block, the input block is returned.
-    pub(crate) fn map_block_index(&self, block_index: u64) -> u64 {
+    pub(crate) fn map_block_index(
+        &self,
+        block_index: FsBlockIndex,
+    ) -> FsBlockIndex {
         *self.block_map.get(&block_index).unwrap_or(&block_index)
     }
 }

--- a/src/journal/block_map.rs
+++ b/src/journal/block_map.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 use crate::Ext4;
+use crate::block_index::FsBlockIndex;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error, IncompatibleKind};
 use crate::inode::Inode;
@@ -25,7 +26,7 @@ use core::iter::Skip;
 
 /// Map from a block somewhere in the filesystem to a block in the
 /// journal. Both the key and value are absolute block indices.
-pub(super) type BlockMap = BTreeMap<u64, u64>;
+pub(super) type BlockMap = BTreeMap<FsBlockIndex, FsBlockIndex>;
 
 /// Read the block map from the journal.
 pub(super) fn load_block_map(
@@ -79,7 +80,7 @@ struct BlockMapLoader<'a> {
     journal_block_iter: Skip<FileBlocks>,
 
     /// Current block index.
-    block_index: u64,
+    block_index: FsBlockIndex,
 
     /// Buffer to hold the current block's data.
     block: Vec<u8>,

--- a/src/journal/descriptor_block.rs
+++ b/src/journal/descriptor_block.rs
@@ -6,6 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use crate::block_index::FsBlockIndex;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error, IncompatibleKind};
 use crate::journal::superblock::JournalSuperblock;
@@ -45,7 +46,7 @@ pub(super) fn validate_descriptor_block_checksum(
 pub(super) struct DescriptorBlockTag {
     /// Absolute block index in the filesystem that should be replaced
     /// with the data block associated with this tag.
-    pub(super) block_index: u64,
+    pub(super) block_index: FsBlockIndex,
 
     /// Checksum of the block data.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@
 extern crate alloc;
 
 mod block_group;
+mod block_index;
 mod block_size;
 mod checksum;
 mod dir;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use block_group::BlockGroupDescriptor;
+use block_index::FsBlockIndex;
 use core::cell::RefCell;
 use core::fmt::{self, Debug, Formatter};
 use error::CorruptKind;
@@ -292,7 +293,7 @@ impl Ext4 {
     /// error is returned.
     fn read_from_block(
         &self,
-        original_block_index: u64,
+        original_block_index: FsBlockIndex,
         offset_within_block: u32,
         dst: &mut [u8],
     ) -> Result<(), Ext4Error> {
@@ -677,7 +678,7 @@ mod tests {
     }
 
     fn block_read_error(
-        block_index: u64,
+        block_index: FsBlockIndex,
         offset_within_block: u32,
         read_len: usize,
     ) -> CorruptKind {


### PR DESCRIPTION
There are a lot of places in the library where a u32 or u64 is used as a block index, and the type of block index (absolute within the filesystem, or relative to the file) is indicated by variable names and comments. Add two named type aliases to help make the intent more obvious.

In the future we might consider converting these type aliases to newtypes, to help catch mistakes at compile time. For now though, type aliases will make the initial conversion easier.

This PR converts many uses of u32/u64 to these type aliases, but probably some places have been missed. They can be filled in later as they are discovered.