### PR TITLE
Deduplicate edition and license keys in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@
 [package]
 name = "ext4-view"
 version = "0.9.1"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+edition.workspace = true
+license.workspace = true
 repository = "https://github.com/nicholasbishop/ext4-view-rs"
 categories = ["filesystem", "embedded", "no-std"]
 description = "No-std compatible Rust library for reading ext2/ext4 filesystems"
@@ -26,6 +26,10 @@ include = [
 
 [workspace]
 members = ["xtask"]
+
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.0", features = ["backtrace"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,8 +9,8 @@
 [package]
 name = "xtask"
 version = "0.0.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+edition.workspace = true
+license.workspace = true
 publish = false
 default-run = "xtask"
 


### PR DESCRIPTION
Add edition/license keys to workspace.package, and use those values in ext4-view and xtask. This will make adding additional packages slightly nicer, and allow changing the edition in just one place when we upgrade to 2024.