### PR TITLE
Add VM benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
+name = "ovmf-prebuilt"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54830fd518fa4cdeb0cd5fad927f0ff6627a41e9705fe874679671108142ccfa"
+dependencies = [
+ "log",
+ "lzma-rs",
+ "sha2",
+ "tar",
+ "ureq",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +468,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -626,6 +659,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79298e11f316400c57ec268f3c2c29ac3c4d4777687955cd3d4f3a35ce7eba"
 dependencies = [
  "bit_field",
+]
+
+[[package]]
+name = "uefi"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25038e420a68d30a0e8002a3b51c075ad2342f5ae7a2383f042bd41fef73272"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "log",
+ "ptr_meta",
+ "ucs2",
+ "uefi-macros",
+ "uefi-raw",
+ "uguid",
+]
+
+[[package]]
+name = "uefi-macros"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cb3027736dad1b6f23437c63249025d960377fe7f9f769a111dfbc0dd2bdda"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d246ed5d6fd71c0331f0ac774a6aefb6cb9170a46f83148cacc70b09f82c87bb"
+dependencies = [
+ "bitflags",
+ "uguid",
+]
+
+[[package]]
+name = "uefibench"
+version = "0.0.0"
+dependencies = [
+ "ext4-view",
+ "sha2",
+ "uefi",
 ]
 
 [[package]]
@@ -827,6 +906,7 @@ dependencies = [
  "libc",
  "lzma-rs",
  "nix",
+ "ovmf-prebuilt",
  "sha2",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ include = [
 ]
 
 [workspace]
-members = ["xtask"]
+members = ["xtask", "xtask/uefibench"]
 
 [workspace.package]
 edition = "2021"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -22,6 +22,7 @@ gpt_disk_io = { version = "0.16.0", features = ["std"] }
 libc = "0.2.155"
 lzma-rs = "0.3.0"
 nix = { version = "0.29.0", features = ["fs", "user"] }
+ovmf-prebuilt = "0.2.2"
 sha2 = "0.10.8"
 tar = "0.4.40"
 tempfile = "3.10.1"

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -10,11 +10,17 @@ mod walk;
 
 use anyhow::Result;
 use ext4_view::Ext4;
-use std::path::Path;
+use ovmf_prebuilt::{Arch, FileType, Prebuilt, Source};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::SystemTime;
+use xtask::run_cmd;
 
 /// Run a simple wall-time performance benchmark.
 pub fn run_bench(path: &Path, iters: u32) -> Result<()> {
+    let vm_inputs = prep_vm()?;
+
     bench_impl(iters, || {
         // Load the filesystem and recursively walk all directories and
         // files. Each file is fully read and hashed.
@@ -23,6 +29,12 @@ pub fn run_bench(path: &Path, iters: u32) -> Result<()> {
         println!("filesystem hash: {digest}");
     });
 
+    bench_impl(iters, || {
+        // Run a VM with the filesystem attached as a disk. The VM runs
+        // a UEFI application which recursively walks all directories
+        // and reads each file.
+        run_vm(&vm_inputs, path).unwrap()
+    });
     Ok(())
 }
 
@@ -50,4 +62,89 @@ where
     let median = durations[durations.len() / 2];
     println!("range: {min:.2?} - {max:.2?}");
     println!("median: {median:.2?}");
+}
+
+fn run_vm(inputs: &VmInputs, filesystem: &Path) -> Result<()> {
+    let code = inputs.prebuilt.get_file(Arch::X64, FileType::Code);
+    let vars = inputs.prebuilt.get_file(Arch::X64, FileType::Vars);
+
+    let mut cmd = Command::new("qemu-system-x86_64");
+    cmd.args(["-nodefaults", "--enable-kvm"]);
+    cmd.args(["-machine", "q35"]);
+    cmd.args(["-m", "1G"]);
+    cmd.args(["-serial", "stdio"]);
+    cmd.args(["-display", "none"]);
+    cmd.args([
+        "-drive",
+        &format!(
+            "if=pflash,format=raw,readonly=on,file={}",
+            code.to_str().unwrap()
+        ),
+    ]);
+    cmd.args([
+        "-drive",
+        &format!(
+            "if=pflash,format=raw,readonly=on,file={}",
+            vars.to_str().unwrap()
+        ),
+    ]);
+    cmd.args([
+        "-drive",
+        &format!("format=raw,file=fat:rw:{}", inputs.esp.to_str().unwrap()),
+    ]);
+
+    // Add a drive for accessing the ext4 filesystem.
+    cmd.args(["-device", "virtio-scsi-pci,id=scsi"]);
+    cmd.args(["-device", "scsi-hd,drive=hd"]);
+    cmd.args([
+        "-drive",
+        &format!(
+            "if=none,id=hd,format=raw,file={}",
+            filesystem.to_str().unwrap()
+        ),
+    ]);
+
+    run_cmd(&mut cmd)?;
+
+    Ok(())
+}
+
+struct VmInputs {
+    esp: PathBuf,
+    prebuilt: Prebuilt,
+}
+
+fn prep_vm() -> Result<VmInputs> {
+    build_uefibench()?;
+    let esp = build_esp()?;
+
+    let prebuilt = Prebuilt::fetch(Source::LATEST, "target/ovmf")
+        .expect("failed to update prebuilt");
+
+    Ok(VmInputs { esp, prebuilt })
+}
+
+fn build_uefibench() -> Result<()> {
+    let mut cmd = Command::new("cargo");
+    cmd.args([
+        "build",
+        "--target",
+        "x86_64-unknown-uefi",
+        "--release",
+        "-p",
+        "uefibench",
+    ]);
+    run_cmd(&mut cmd)
+}
+
+fn build_esp() -> Result<PathBuf> {
+    let esp = Path::new("target/esp");
+    let boot = esp.join("efi/boot");
+    fs::create_dir_all(&boot)?;
+    fs::copy(
+        "target/x86_64-unknown-uefi/release/uefibench.efi",
+        boot.join("bootx64.efi"),
+    )?;
+
+    Ok(esp.to_owned())
 }

--- a/xtask/src/bench/walk.rs
+++ b/xtask/src/bench/walk.rs
@@ -6,6 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// Note: this file is used as a module in `bench.rs`, but is also used
+// via an `include!` in `xtask/uefibench`.
+
+use alloc::string::String;
+use alloc::{format, vec};
 use ext4_view::{Ext4, Ext4Error, File, Path};
 use sha2::{Digest, Sha256};
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+extern crate alloc;
+
 mod bench;
 mod big_fs;
 mod dmsetup;

--- a/xtask/uefibench/Cargo.toml
+++ b/xtask/uefibench/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "uefibench"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+autotests = false
+
+[dependencies]
+ext4-view = { path = "../.." }
+sha2 = { version = "0.10.8", default-features = false }
+uefi = { version = "0.34.1", features = ["alloc"] }
+
+[target.'cfg(target_os = "uefi")'.dependencies]
+uefi = { version = "0.34.1", features = ["global_allocator", "panic_handler"] }

--- a/xtask/uefibench/src/main.rs
+++ b/xtask/uefibench/src/main.rs
@@ -1,0 +1,85 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![no_main]
+#![no_std]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use core::error::Error;
+use ext4_view::{Ext4, Ext4Read};
+use uefi::boot::{OpenProtocolAttributes, OpenProtocolParams, ScopedProtocol};
+use uefi::proto::media::block::BlockIO;
+use uefi::proto::media::disk::DiskIo;
+use uefi::runtime::ResetType;
+use uefi::{Handle, Status, boot, println, runtime};
+
+mod walk {
+    use uefi::println as eprintln;
+
+    include!("../../src/bench/walk.rs");
+}
+
+struct Disk {
+    media_id: u32,
+    io: ScopedProtocol<DiskIo>,
+}
+
+impl Ext4Read for Disk {
+    fn read(
+        &mut self,
+        start_byte: u64,
+        dst: &mut [u8],
+    ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+        Ok(self
+            .io
+            .read_disk(self.media_id, start_byte, dst)
+            .map_err(Box::new)?)
+    }
+}
+
+fn get_media_id(handle: Handle) -> uefi::Result<u32> {
+    // Safety: nothing else should be accessing the disk.
+    let bio = unsafe {
+        boot::open_protocol::<BlockIO>(
+            OpenProtocolParams {
+                handle,
+                agent: boot::image_handle(),
+                controller: None,
+            },
+            OpenProtocolAttributes::GetProtocol,
+        )
+    }?;
+    Ok(bio.media().media_id())
+}
+
+#[uefi::entry]
+fn main() -> Status {
+    let handles = boot::find_handles::<DiskIo>().unwrap();
+
+    for handle in handles {
+        let media_id = if let Ok(media_id) = get_media_id(handle) {
+            media_id
+        } else {
+            continue;
+        };
+
+        if let Ok(io) = boot::open_protocol_exclusive::<DiskIo>(handle) {
+            if let Ok(fs) = Ext4::load(Box::new(Disk { media_id, io })) {
+                println!("starting walk...");
+                let digest = walk::walk(&fs).unwrap();
+                println!("filesystem hash: {digest}");
+
+                runtime::reset(ResetType::SHUTDOWN, Status::SUCCESS, None);
+            }
+        }
+    }
+
+    panic!("failed to open ext4 filesystem");
+}


### PR DESCRIPTION
This extends the `xtask bench` action to also run a benchmark inside a VM. This takes the form of a simple UEFI application.

The big difference between this and the "host" benchmark is that the VM disk driver isn't doing any fancy caching or coalescing of reads. So it is currently a good bit slower than the host bench.

The VM benchmark is also pretty naive in terms of the measurement. The measurement is done outside the VM, because it's not trivial to access a high-res clock in a UEFI app in a VM. The measurement includes QEMU startup/shutdown time. This might be improved in the future; for now I'm just doing the simplest thing that works.