### PR TITLE
Silence a clippy lint to fix the beta channel build

### DIFF
--- a/src/iters/file_blocks.rs
+++ b/src/iters/file_blocks.rs
@@ -18,6 +18,7 @@ use extents_blocks::ExtentsBlocks;
 // This enum is separate from `FileBlocks` to keep the implementation
 // details private to this module; members of an enum cannot be more
 // private than the enum itself.
+#[allow(clippy::large_enum_variant)]
 enum FileBlocksInner {
     ExtentsBlocks(ExtentsBlocks),
     BlockMap(BlockMap),


### PR DESCRIPTION
This lint is saying that the FileBlocksInner variants have fairly different sizes (~100 vs ~300 bytes), but I don't think that's significant here.