### PR TITLE
Update webpki-roots to 0.26.10

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -13,9 +13,9 @@ allow = [
 
   # Needed for xtask only.
   "BSD-3-Clause",
+  "CDLA-Permissive-2.0",
   "ISC",
   "MPL-2.0",
-  "OpenSSL",
   "Unicode-3.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
 dependencies = [
  "rustls-pki-types",
 ]


### PR DESCRIPTION
This requires an additional license, see
https://github.com/rustls/webpki-roots/commit/90c48f38672f.

Also remove the OpenSSL license, no longer used.