### PR TITLE
Replace doc_auto_cfg with doc_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //! [issues]: https://github.com/nicholasbishop/ext4-view-rs/issues
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::arithmetic_side_effects,


### PR DESCRIPTION
The `doc_auto_cfg` feature has been subsumed by `doc_cfg`: https://github.com/rust-lang/rust/pull/138907