### PR TITLE
Increase MSRV to 1.85 and switch to 2024 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* MSRV increased to `1.85`.
+
 ## 0.9.3
 
 * Added support for TEA hashes in directory blocks.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/nicholasbishop/ext4-view-rs"
 categories = ["filesystem", "embedded", "no-std"]
 description = "No-std compatible Rust library for reading ext2/ext4 filesystems"
 keywords = ["ext4", "filesystem", "no_std"]
-rust-version = "1.81"
+rust-version = "1.85"
 include = [
     "src/*.rs",
     "src/iters",
@@ -28,7 +28,7 @@ include = [
 members = ["xtask", "xtask/uefibench"]
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/xtask/uefibench/src/main.rs
+++ b/xtask/uefibench/src/main.rs
@@ -70,14 +70,14 @@ fn main() -> Status {
             continue;
         };
 
-        if let Ok(io) = boot::open_protocol_exclusive::<DiskIo>(handle) {
-            if let Ok(fs) = Ext4::load(Box::new(Disk { media_id, io })) {
-                println!("starting walk...");
-                let digest = walk::walk(&fs).unwrap();
-                println!("filesystem hash: {digest}");
+        if let Ok(io) = boot::open_protocol_exclusive::<DiskIo>(handle)
+            && let Ok(fs) = Ext4::load(Box::new(Disk { media_id, io }))
+        {
+            println!("starting walk...");
+            let digest = walk::walk(&fs).unwrap();
+            println!("filesystem hash: {digest}");
 
-                runtime::reset(ResetType::SHUTDOWN, Status::SUCCESS, None);
-            }
+            runtime::reset(ResetType::SHUTDOWN, Status::SUCCESS, None);
         }
     }
 


### PR DESCRIPTION
1.85 is the first release that supports the 2024 edition. It's also the rust version in the latest debian stable, so it's becoming a common MSRV in the crate ecosystem.

The change in xtask fixes a new clippy lint.