### PR TITLE
Use unwrap in BlockSize::to_nz_u64

### DIFF
--- a/src/block_size.rs
+++ b/src/block_size.rs
@@ -45,13 +45,8 @@ impl BlockSize {
     }
 
     pub(crate) const fn to_nz_u64(self) -> NonZero<u64> {
-        // TODO: this would be OK to `unwrap`, but can't use `unwrap` in
-        // a const function until Rust 1.83.
-        if let Some(nz) = NonZero::new(self.to_u64()) {
-            nz
-        } else {
-            unreachable!()
-        }
+        // OK to unwrap: a `NonZero<u32>` always fits in a `NonZero<u64>`.
+        NonZero::new(self.to_u64()).unwrap()
     }
 
     pub(crate) const fn to_usize(self) -> usize {


### PR DESCRIPTION
As of Rust 1.83, unwrap can be used in const functions. The MSRV of this crate is now 1.85, so it's OK to use.