### PR TITLE
Update `Ext4Error` -> `std::io::Error` with new variants

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -144,22 +144,22 @@ impl From<Ext4Error> for std::io::Error {
     fn from(e: Ext4Error) -> Self {
         use std::io::ErrorKind::*;
 
-        // TODO: Rust 1.83 adds NotADirectory, IsADirectory, and
-        // FileTooLarge to std::io::Error; use those after bumping the
-        // MSRV.
+        // TODO: Rust 1.87 adds InvalidFilename; use after bumping the MSRV.
         match e {
-            Ext4Error::IsADirectory
-            | Ext4Error::IsASpecialFile
+            Ext4Error::IsASpecialFile
             | Ext4Error::MalformedPath
-            | Ext4Error::NotADirectory
             | Ext4Error::NotASymlink
             | Ext4Error::NotAbsolute => InvalidInput.into(),
+
             Ext4Error::Corrupt(_)
-            | Ext4Error::FileTooLarge
             | Ext4Error::Incompatible(_)
             | Ext4Error::PathTooLong
             | Ext4Error::TooManySymlinks => Self::other(e),
+
+            Ext4Error::FileTooLarge => FileTooLarge.into(),
             Ext4Error::Io(inner) => Self::other(inner),
+            Ext4Error::IsADirectory => IsADirectory.into(),
+            Ext4Error::NotADirectory => NotADirectory.into(),
             Ext4Error::NotFound => NotFound.into(),
             Ext4Error::NotUtf8 => InvalidData.into(),
             Ext4Error::Encrypted => PermissionDenied.into(),


### PR DESCRIPTION
Several new variants of `std::io::Error` were stabilized in 1.83; make use of them when converting from `Ext4Error`. Also update the TODO with an error that will be available after the MSRV is bumped to 1.87 or later.