### PR TITLE
Change `DirEntry::from_bytes` to use `NonZero` for entry size

### DIFF
--- a/src/dir_htree.rs
+++ b/src/dir_htree.rs
@@ -382,7 +382,7 @@ pub(crate) fn get_dir_entry_via_htree(
             path.clone(),
         )?;
         offset_within_block = offset_within_block
-            .checked_add(entry_size)
+            .checked_add(entry_size.get())
             .ok_or(CorruptKind::DirEntry(inode.index))?;
         let Some(dir_entry) = dir_entry else {
             continue;

--- a/src/iters/read_dir.rs
+++ b/src/iters/read_dir.rs
@@ -142,7 +142,7 @@ impl ReadDir {
 
         self.offset_within_block = self
             .offset_within_block
-            .checked_add(entry_size)
+            .checked_add(entry_size.get())
             .ok_or(CorruptKind::DirEntry(self.inode))?;
 
         Ok(entry)


### PR DESCRIPTION
This serves to statically enforce an important property of `DirEntry::from_bytes`: it must never return zero, because iterators that call it would get stuck in an infinite loop.

This was already checked at runtime with `rec_len < NAME_OFFSET`, this change just enforces it statically.