### PR TITLE
Improve various `Debug` impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Improved error messages for various directory entry corruption errors.
 * Changed the `Debug` impls for stringish types (such as `DirEntryName`
   and `Path`) to wrap the string in quotes, matching `std` behavior`.
+* Changed the `Debug` impl for `DirEntry` to just show the path,
+  matching `std` behavior.
 
 ## 0.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * MSRV increased to `1.85`.
 * Improved error messages for various directory entry corruption errors.
+* Changed the `Debug` impls for stringish types (such as `DirEntryName`
+  and `Path`) to wrap the string in quotes, matching `std` behavior`.
 
 ## 0.9.3
 

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -202,7 +202,7 @@ impl TryFrom<&[u8]> for DirEntryNameBuf {
 }
 
 /// Directory entry.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct DirEntry {
     fs: Ext4,
 
@@ -348,6 +348,12 @@ impl DirEntry {
     pub fn metadata(&self) -> Result<Metadata, Ext4Error> {
         let inode = Inode::read(&self.fs, self.inode)?;
         Ok(inode.metadata)
+    }
+}
+
+impl Debug for DirEntry {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DirEntry").field(&self.path()).finish()
     }
 }
 

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -359,7 +359,7 @@ mod tests {
     #[test]
     fn test_dir_entry_debug() {
         let src = "abc😁\n".as_bytes();
-        let expected = "abc😁\\n"; // Note the escaped slash.
+        let expected = r#""abc😁\n""#; // Note the escaped slash.
         assert_eq!(format!("{:?}", DirEntryName(src)), expected);
 
         let mut src_vec = src.to_vec();

--- a/src/format.rs
+++ b/src/format.rs
@@ -22,12 +22,12 @@ pub(crate) fn format_bytes_debug(
     if let Ok(s) = str::from_utf8(bytes) {
         // For valid UTF-8, print it unmodified except for escaping
         // special characters like newlines.
-        write!(f, "{}", s.escape_debug())
+        write!(f, "\"{}\"", s.escape_debug())
     } else {
         // Otherwise, print valid ASCII characters (again, with special
         // characters like newlines escaped). Non-ASCII bytes are
         // printed in "\xHH" format.
-        write!(f, "{}", bytes.escape_ascii())
+        write!(f, "\"{}\"", bytes.escape_ascii())
     }
 }
 
@@ -62,12 +62,12 @@ mod tests {
         let f = |b: &[u8]| format!("{:?}", S(b));
 
         // Valid UTF-8.
-        assert_eq!(f("abc😁".as_bytes()), "abc😁");
-        assert_eq!(f("abc\n".as_bytes()), r"abc\n");
+        assert_eq!(f("abc😁".as_bytes()), r#""abc😁""#);
+        assert_eq!(f("abc\n".as_bytes()), r#""abc\n""#);
 
         // Invalid UTF-8.
-        assert_eq!(f(&[0xc3, 0x28]), r"\xc3(");
-        assert_eq!(f(&[0xc3, 0x28, b'\n']), r"\xc3(\n");
+        assert_eq!(f(&[0xc3, 0x28]), r#""\xc3(""#);
+        assert_eq!(f(&[0xc3, 0x28, b'\n']), r#""\xc3(\n""#);
     }
 
     #[test]

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -300,6 +300,19 @@ fn test_metadata_uid_gid() {
 }
 
 #[test]
+fn test_direntry_debug() {
+    let fs = load_test_disk1();
+    let entry = fs
+        .read_dir("/")
+        .unwrap()
+        .map(|e| e.unwrap())
+        .find(|e| e.file_name() == "small_file")
+        .unwrap();
+    assert_eq!(format!("{:?}", entry.path()), r#""/small_file""#);
+    assert_eq!(format!("{entry:?}"), r#"DirEntry("/small_file")"#);
+}
+
+#[test]
 fn test_direntry_metadata() {
     let fs = load_test_disk1();
 

--- a/tests/integration/label.rs
+++ b/tests/integration/label.rs
@@ -14,7 +14,7 @@ fn test_label_empty() {
     let label = Label::new([0; 16]);
     assert_eq!(label.to_str().unwrap(), "");
     assert_eq!(*label.as_bytes(), [0; 16]);
-    assert_eq!(format!("{label:?}"), "");
+    assert_eq!(format!("{label:?}"), r#""""#);
     assert_eq!(format!("{}", label.display()), "");
 }
 
@@ -24,7 +24,7 @@ fn test_label_utf8_with_null() {
     let label = Label::new(*bytes);
     assert_eq!(label.to_str().unwrap(), "test label");
     assert_eq!(label.as_bytes(), bytes);
-    assert_eq!(format!("{label:?}"), "test label");
+    assert_eq!(format!("{label:?}"), r#""test label""#);
     assert_eq!(format!("{}", label.display()), "test label");
 }
 
@@ -34,7 +34,7 @@ fn test_label_utf8_with_interior_null() {
     let label = Label::new(*bytes);
     assert_eq!(label.to_str().unwrap(), "abc");
     assert_eq!(label.as_bytes(), bytes);
-    assert_eq!(format!("{label:?}"), "abc");
+    assert_eq!(format!("{label:?}"), r#""abc""#);
     assert_eq!(format!("{}", label.display()), "abc");
 }
 
@@ -44,7 +44,7 @@ fn test_label_utf8_max_len() {
     let label = Label::new(*bytes);
     assert_eq!(label.to_str().unwrap(), "0123456789abcdef");
     assert_eq!(label.as_bytes(), bytes);
-    assert_eq!(format!("{label:?}"), "0123456789abcdef");
+    assert_eq!(format!("{label:?}"), r#""0123456789abcdef""#);
     assert_eq!(format!("{}", label.display()), "0123456789abcdef");
 }
 
@@ -54,7 +54,7 @@ fn test_label_not_utf8() {
     let label = Label::new(bytes);
     assert!(label.to_str().is_err());
     assert_eq!(*label.as_bytes(), bytes);
-    assert_eq!(format!("{label:?}"), "\\xc0");
+    assert_eq!(format!("{label:?}"), r#""\xc0""#);
     assert_eq!(format!("{}", label.display()), "�");
 }
 

--- a/tests/integration/path.rs
+++ b/tests/integration/path.rs
@@ -104,7 +104,7 @@ fn test_path_construction_windows_non_utf8() {
 #[test]
 fn test_path_debug() {
     let src = "abc😁\n".as_bytes();
-    let expected = "abc😁\\n"; // Note the escaped slash.
+    let expected = r#""abc😁\n""#; // Note the escaped slash.
     assert_eq!(format!("{:?}", Path::new(src)), expected);
     assert_eq!(format!("{:?}", PathBuf::new(src)), expected);
 }
@@ -253,7 +253,7 @@ fn test_component() {
     assert_eq!(format!("{:?}", Component::ParentDir), "ParentDir");
     assert_eq!(
         format!("{:?}", Component::normal("abc").unwrap()),
-        "Normal(abc)"
+        "Normal(\"abc\")"
     );
 }
 

--- a/tests/integration/path.rs
+++ b/tests/integration/path.rs
@@ -103,10 +103,18 @@ fn test_path_construction_windows_non_utf8() {
 
 #[test]
 fn test_path_debug() {
-    let src = "abc😁\n".as_bytes();
+    let src = "abc😁\n";
     let expected = r#""abc😁\n""#; // Note the escaped slash.
     assert_eq!(format!("{:?}", Path::new(src)), expected);
     assert_eq!(format!("{:?}", PathBuf::new(src)), expected);
+
+    // Test that the path types in this library have the same `Debug`
+    // format as the `std` path types.
+    #[cfg(feature = "std")]
+    {
+        assert_eq!(format!("{:?}", std::path::Path::new(src)), expected);
+        assert_eq!(format!("{:?}", std::path::PathBuf::from(src)), expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Stringish types such as `Path` now wrap the output in quotes to match how `std` behaves. The `DirEntry` `Debug` impl now just shows the interior path, again matching `std`.

Fixes https://github.com/nicholasbishop/ext4-view-rs/issues/530