### PR TITLE
Reject superblock with zero blocks_per_group

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -203,6 +203,9 @@ pub(crate) enum CorruptKind {
     /// The number of inodes per block group is zero.
     InodesPerBlockGroup,
 
+    /// The number of blocks per group is zero.
+    BlocksPerGroup,
+
     /// The inode size exceeds the block size.
     InodeSize,
 
@@ -391,6 +394,9 @@ impl Display for CorruptKind {
             Self::TooManyBlockGroups => write!(f, "too many block groups"),
             Self::InodesPerBlockGroup => {
                 write!(f, "inodes per block group is zero")
+            }
+            Self::BlocksPerGroup => {
+                write!(f, "blocks per group is zero")
             }
             Self::InodeSize => write!(f, "inode size is invalid"),
             Self::JournalInode => write!(f, "invalid journal inode"),

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -101,8 +101,10 @@ impl Superblock {
         // `num_data_blocks = 3` and `s_blocks_per_group = 4`; that is
         // one block group, but regular division would calculate zero
         // instead of one.)
+        let blocks_per_group = NonZero::new(s_blocks_per_group)
+            .ok_or(CorruptKind::BlocksPerGroup)?;
         let num_block_groups = u32::try_from(
-            num_data_blocks.div_ceil(u64::from(s_blocks_per_group)),
+            num_data_blocks.div_ceil(u64::from(blocks_per_group.get())),
         )
         .map_err(|_| CorruptKind::TooManyBlockGroups)?;
 
@@ -360,6 +362,23 @@ mod tests {
             IncompatibleKind::UnsupportedFeatures(
                 IncompatibleFeatures::from_bits_retain(0x2_0000)
             )
+        );
+    }
+
+    /// Test that an error is returned if `s_blocks_per_group` is zero,
+    /// rather than panicking with a divide-by-zero in `div_ceil`.
+    #[test]
+    fn test_blocks_per_group_zero() {
+        let mut data =
+            include_bytes!("../test_data/raw_superblock.bin").to_vec();
+        // s_blocks_per_group is a 4-byte LE field at offset 0x20.
+        data[0x20] = 0;
+        data[0x21] = 0;
+        data[0x22] = 0;
+        data[0x23] = 0;
+        assert_eq!(
+            Superblock::from_bytes(&data).unwrap_err(),
+            CorruptKind::BlocksPerGroup
         );
     }
 


### PR DESCRIPTION
## Problem

`s_blocks_per_group` is read directly from the (untrusted) superblock and used as a
divisor in `div_ceil` during superblock parsing:

```rust
num_data_blocks.div_ceil(u64::from(s_blocks_per_group))
```

When `s_blocks_per_group == 0`, this panics with "attempt to divide by zero" in
`Ext4::load`, before any file access. Found via `cargo-fuzz`.

## Fix

Guard `s_blocks_per_group` with `NonZero` and return a new
`CorruptKind::BlocksPerGroup` error when it's zero — mirroring the existing
`s_inodes_per_group` check on the following line.

## Test

Adds `test_blocks_per_group_zero`, which loads the test superblock, sets
`s_blocks_per_group` to zero, and asserts `from_bytes` returns
`CorruptKind::BlocksPerGroup` instead of panicking.

Fixes: #563 