### PR TITLE
feat: Add trace-level logging to journal reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   and `Path`) to wrap the string in quotes, matching `std` behavior`.
 * Changed the `Debug` impl for `DirEntry` to just show the path,
   matching `std` behavior.
+* Added `trace`-level logging (via the `log` crate) at some journal
+  read points, to aid debugging. Paths and data block contents are
+  never logged.
 
 ## 0.9.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "crc",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ std = []
 [dependencies]
 bitflags = "2.0.0"
 crc = "3.0.0"
+log = "0.4.0"
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -43,6 +43,7 @@ impl Journal {
         let Some(journal_inode) = fs.0.superblock.journal_inode else {
             // Return an empty journal if this filesystem does not have
             // a journal.
+            log::trace!("filesystem has no journal; using empty journal");
             return Ok(Self::empty());
         };
 

--- a/src/journal/block_map.rs
+++ b/src/journal/block_map.rs
@@ -46,6 +46,9 @@ pub(super) fn load_block_map(
             if let Ext4Error::Corrupt(_) = err {
                 // If a corruption error occurred, stop reading the
                 // journal. Any uncommitted changes are discarded.
+                log::trace!(
+                    "stopping journal read due to corruption error: {err:?}"
+                );
                 break;
             } else {
                 // Propagate any other type of error.


### PR DESCRIPTION
Adds `trace`-level logging to journal reading, as discussed in #447.
Uses the `log` crate (no-std compatible) and emits `trace!` at two points in journal reading:

when a corruption error stops journal reading (`journal/block_map.rs`) — this is the case where errors are currently tolerated silently, so a trace makes it visible when debugging
when a filesystem has no journal (`journal.rs`)

Paths and data block contents are never logged.
This is meant as a starting point / pattern — happy to extend trace logging to other areas (superblock/inode parsing, error paths, etc.) in follow-ups if the approach looks right.

Fixes : #447 
Signed off by : @abhiprd2000 