### PR TITLE
Expose inode index, link count, and block count on Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added `Metadata::inode`, `Metadata::nlink`, and `Metadata::blocks` to
+  expose the inode index, hard link count, and allocated 512-byte sector
+  count.
 * MSRV increased to `1.85`.
 * Improved error messages for various directory entry corruption errors.
 * Changed the `Debug` impls for stringish types (such as `DirEntryName`

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -183,21 +183,26 @@ impl Inode {
         let mode = InodeMode::from_bits_retain(i_mode);
         let flags = InodeFlags::from_bits_retain(i_flags);
 
-        // The `i_blocks` field normally counts 512-byte sectors, and the
-        // upper 16 bits in `l_i_blocks_high` are only meaningful when the
-        // file system has the `huge_file` feature. When that feature is
-        // present *and* the inode has the `HUGE_FILE` flag, the field
-        // counts file system blocks instead of sectors.
-        let raw_blocks = if ext4.has_huge_files() {
-            u64_from_hilo(u32::from(l_i_blocks_high), i_blocks_lo)
+        // The `i_blocks` field normally counts 512-byte sectors. Both of the
+        // things that can change that depend on the `huge_file` feature:
+        // without it the upper 16 bits at 0x74 are `l_i_reserved` rather
+        // than a block count, and the `HUGE_FILE` inode flag means nothing.
+        // `ext4_inode_blocks` in the kernel puts both steps inside the same
+        // feature check, so a flag set without the feature does not scale
+        // anything here either.
+        let blocks = if ext4.has_huge_files() {
+            let combined =
+                u64_from_hilo(u32::from(l_i_blocks_high), i_blocks_lo);
+            if flags.contains(InodeFlags::HUGE_FILE) {
+                // With the flag the field counts file system blocks, so it
+                // is scaled to the 512-byte units the name promises.
+                combined
+                    .saturating_mul(ext4.0.superblock.block_size.to_u64() / 512)
+            } else {
+                combined
+            }
         } else {
             u64::from(i_blocks_lo)
-        };
-        let blocks = if flags.contains(InodeFlags::HUGE_FILE) {
-            raw_blocks
-                .saturating_mul(ext4.0.superblock.block_size.to_u64() / 512)
-        } else {
-            raw_blocks
         };
 
         let mut checksum_base =

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -153,11 +153,15 @@ impl Inode {
         let i_uid = read_u16le(data, 0x2);
         let i_size_lo = read_u32le(data, 0x4);
         let i_gid = read_u16le(data, 0x18);
+        let i_links_count = read_u16le(data, 0x1a);
+        let i_blocks_lo = read_u32le(data, 0x1c);
         let i_flags = read_u32le(data, 0x20);
         // OK to unwrap: already checked the length.
         let i_block = data.get(0x28..0x28 + Self::INLINE_DATA_LEN).unwrap();
         let i_generation = read_u32le(data, 0x64);
         let i_size_high = read_u32le(data, 0x6c);
+        // `l_i_blocks_high` is the first field of the `osd2` union at 0x74.
+        let l_i_blocks_high = read_u16le(data, 0x74);
         let l_i_uid_high = read_u16le(data, 0x74 + 0x4);
         let l_i_gid_high = read_u16le(data, 0x74 + 0x6);
         let (l_i_checksum_lo, i_checksum_hi) = if ext4.has_metadata_checksums()
@@ -177,6 +181,24 @@ impl Inode {
         let gid = u32_from_hilo(l_i_gid_high, i_gid);
         let checksum = u32_from_hilo(i_checksum_hi, l_i_checksum_lo);
         let mode = InodeMode::from_bits_retain(i_mode);
+        let flags = InodeFlags::from_bits_retain(i_flags);
+
+        // The `i_blocks` field normally counts 512-byte sectors, and the
+        // upper 16 bits in `l_i_blocks_high` are only meaningful when the
+        // file system has the `huge_file` feature. When that feature is
+        // present *and* the inode has the `HUGE_FILE` flag, the field
+        // counts file system blocks instead of sectors.
+        let raw_blocks = if ext4.has_huge_files() {
+            u64_from_hilo(u32::from(l_i_blocks_high), i_blocks_lo)
+        } else {
+            u64::from(i_blocks_lo)
+        };
+        let blocks = if flags.contains(InodeFlags::HUGE_FILE) {
+            raw_blocks
+                .saturating_mul(ext4.0.superblock.block_size.to_u64() / 512)
+        } else {
+            raw_blocks
+        };
 
         let mut checksum_base =
             Checksum::with_seed(ext4.0.superblock.checksum_seed);
@@ -203,8 +225,11 @@ impl Inode {
                     file_type: FileType::try_from(mode).map_err(|_| {
                         CorruptKind::InodeFileType { inode: index, mode }
                     })?,
+                    inode: index.get(),
+                    nlink: i_links_count,
+                    blocks,
                 },
-                flags: InodeFlags::from_bits_retain(i_flags),
+                flags,
                 checksum_base,
                 file_size_in_blocks,
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,8 +263,6 @@ impl Ext4 {
         self.0.superblock.uuid
     }
 
-    /// Return true if the filesystem has metadata checksums enabled,
-    /// false otherwise.
     /// Whether the file system has the `huge_file` feature, which changes
     /// how the inode's block count field is interpreted.
     fn has_huge_files(&self) -> bool {
@@ -274,6 +272,8 @@ impl Ext4 {
             .contains(ReadOnlyCompatibleFeatures::HUGE_FILES)
     }
 
+    /// Return true if the filesystem has metadata checksums enabled,
+    /// false otherwise.
     fn has_metadata_checksums(&self) -> bool {
         self.0
             .superblock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,15 @@ impl Ext4 {
 
     /// Return true if the filesystem has metadata checksums enabled,
     /// false otherwise.
+    /// Whether the file system has the `huge_file` feature, which changes
+    /// how the inode's block count field is interpreted.
+    fn has_huge_files(&self) -> bool {
+        self.0
+            .superblock
+            .read_only_compatible_features
+            .contains(ReadOnlyCompatibleFeatures::HUGE_FILES)
+    }
+
     fn has_metadata_checksums(&self) -> bool {
         self.0
             .superblock

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -26,6 +26,15 @@ pub struct Metadata {
 
     /// Owner group ID.
     pub(crate) gid: u32,
+
+    /// Index of the inode this metadata came from.
+    pub(crate) inode: u32,
+
+    /// Number of hard links to the file.
+    pub(crate) nlink: u16,
+
+    /// Number of 512-byte sectors allocated to the file.
+    pub(crate) blocks: u64,
 }
 
 impl Metadata {
@@ -90,5 +99,44 @@ impl Metadata {
     #[must_use]
     pub fn gid(&self) -> u32 {
         self.gid
+    }
+
+    /// Index of the inode this metadata came from.
+    ///
+    /// Inode indices start at one, so this is never zero. Two paths with
+    /// the same inode index refer to the same file (for example, hard
+    /// links).
+    #[must_use]
+    pub fn inode(&self) -> u32 {
+        self.inode
+    }
+
+    /// Number of hard links to the file.
+    ///
+    /// Note that when the file system has the `dir_nlink` feature and a
+    /// directory has more than 64,999 subdirectories, the on-disk link
+    /// count is set to one to indicate that the real count is unknown. In
+    /// that case this method returns one.
+    ///
+    /// See `st_nlink` in [inode(7)][inode] for more details.
+    ///
+    /// [inode]: https://www.man7.org/linux/man-pages/man7/inode.7.html
+    #[must_use]
+    pub fn nlink(&self) -> u16 {
+        self.nlink
+    }
+
+    /// Number of 512-byte sectors actually allocated to the file.
+    ///
+    /// This can be smaller than [`len`][Self::len] divided by 512 for a
+    /// sparse file, and larger for a file with indirect blocks or extent
+    /// tree nodes, since those count towards the allocation too.
+    ///
+    /// See `st_blocks` in [inode(7)][inode] for more details.
+    ///
+    /// [inode]: https://www.man7.org/linux/man-pages/man7/inode.7.html
+    #[must_use]
+    pub fn blocks(&self) -> u64 {
+        self.blocks
     }
 }

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -300,6 +300,46 @@ fn test_metadata_uid_gid() {
 }
 
 #[test]
+fn test_metadata_inode_nlink_blocks() {
+    let fs = load_test_disk1();
+
+    // The expected values in this test were obtained independently, with
+    // `debugfs -R "stat <path>" test_disk1.bin` from e2fsprogs.
+
+    let metadata = fs.metadata("/small_file").unwrap();
+    assert_eq!(metadata.inode(), 14);
+    assert_eq!(metadata.nlink(), 1);
+    assert_eq!(metadata.blocks(), 2);
+
+    // A directory with one subdirectory has three links: its entry in the
+    // parent directory, its own ".", and the subdirectory's "..".
+    let metadata = fs.metadata("/dir1").unwrap();
+    assert_eq!(metadata.inode(), 2050);
+    assert_eq!(metadata.nlink(), 3);
+    assert_eq!(metadata.blocks(), 2);
+
+    // A sparse file allocates fewer sectors than its length implies.
+    let metadata = fs.metadata("/holes").unwrap();
+    assert_eq!(metadata.inode(), 11031);
+    assert_eq!(metadata.len(), 10240);
+    assert_eq!(metadata.blocks(), 8);
+    assert!(metadata.blocks() * 512 < metadata.len());
+
+    // Paths reached through a symlink resolve to the target's inode.
+    assert_eq!(
+        fs.metadata("/sym_simple").unwrap().inode(),
+        fs.metadata("/small_file").unwrap().inode()
+    );
+
+    // `symlink_metadata` does not follow the link, so it reports the
+    // symlink's own inode.
+    assert_ne!(
+        fs.symlink_metadata("/sym_simple").unwrap().inode(),
+        fs.metadata("/small_file").unwrap().inode()
+    );
+}
+
+#[test]
 fn test_direntry_debug() {
     let fs = load_test_disk1();
     let entry = fs


### PR DESCRIPTION
`Metadata` currently exposes size, mode, uid and gid, but the inode carries a few more fields that callers cannot reach. This adds three of them:

- **`Metadata::inode`** — the inode index. Lets callers tell that two paths refer to the same file, and gives them a stable 64-bit-safe file identifier. That last part is what motivated this: when exposing an ext4 volume through a file system server (NFS, FSKit) a stable file id is mandatory, and without the inode index it has to be synthesised from paths, which breaks hard links and costs a side table.
- **`Metadata::nlink`** — the hard link count. Documented including the `dir_nlink` case where the on-disk count is `1` to mean "unknown".
- **`Metadata::blocks`** — allocated 512-byte sectors, matching `std::os::unix::fs::MetadataExt::blocks`. This is what distinguishes a sparse file from a dense one.

`i_blocks` needs a little care, and both cases are handled:

- the upper 16 bits in `l_i_blocks_high` are only meaningful when the file system has the `huge_file` feature;
- when that feature is present *and* the inode has the `HUGE_FILE` flag, the field counts file system blocks rather than 512-byte sectors.

### Testing

`cargo test`, `cargo clippy --workspace` and `cargo fmt --check` are clean (the one pre-existing `arithmetic_side_effects` warning in `block_cache.rs` is untouched).

The expected values in the new test were obtained independently, with `debugfs -R "stat <path>"` from e2fsprogs against the same test disk — not from this implementation. The test also covers the sparse `/holes` file, where `blocks() * 512 < len()`.

### Note

I have not signed the Google CLA yet. Happy to do that if you are interested in the change.