### PR TITLE
Expose file timestamps on Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Added `Metadata::atime`, `Metadata::ctime`, `Metadata::mtime`, and
+  `Metadata::crtime`, along with the `Timestamp` type they return.
 * MSRV increased to `1.85`.
 * Improved error messages for various directory entry corruption errors.
 * Changed the `Debug` impls for stringish types (such as `DirEntryName`

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -13,6 +13,7 @@ use crate::error::{CorruptKind, Ext4Error};
 use crate::file_type::FileType;
 use crate::metadata::Metadata;
 use crate::path::PathBuf;
+use crate::timestamp::Timestamp;
 use crate::util::{
     read_u16le, read_u32le, u32_from_hilo, u64_from_hilo, usize_from_u32,
 };
@@ -152,6 +153,9 @@ impl Inode {
         let i_mode = read_u16le(data, 0x0);
         let i_uid = read_u16le(data, 0x2);
         let i_size_lo = read_u32le(data, 0x4);
+        let i_atime = read_u32le(data, 0x8);
+        let i_ctime = read_u32le(data, 0xc);
+        let i_mtime = read_u32le(data, 0x10);
         let i_gid = read_u16le(data, 0x18);
         let i_flags = read_u32le(data, 0x20);
         // OK to unwrap: already checked the length.
@@ -178,6 +182,39 @@ impl Inode {
         let checksum = u32_from_hilo(i_checksum_hi, l_i_checksum_lo);
         let mode = InodeMode::from_bits_retain(i_mode);
 
+        // The nanosecond parts of the timestamps, and the creation time,
+        // live past the 128-byte "good old" inode. They are only present if
+        // `i_extra_isize` says the inode is big enough, mirroring the
+        // kernel's `EXT4_FITS_IN_INODE` check.
+        let i_extra_isize = if data.len() >= 0x82 {
+            read_u16le(data, 0x80)
+        } else {
+            0
+        };
+        let extra_fields_end =
+            128usize.saturating_add(usize::from(i_extra_isize));
+        let extra_field = |offset: usize| -> u32 {
+            let end = offset.saturating_add(4);
+            if end <= extra_fields_end && end <= data.len() {
+                read_u32le(data, offset)
+            } else {
+                0
+            }
+        };
+        let has_crtime = 0x94 <= extra_fields_end && 0x94 <= data.len();
+
+        let atime = Timestamp::from_inode_fields(i_atime, extra_field(0x8c));
+        let ctime = Timestamp::from_inode_fields(i_ctime, extra_field(0x84));
+        let mtime = Timestamp::from_inode_fields(i_mtime, extra_field(0x88));
+        let crtime = if has_crtime {
+            Some(Timestamp::from_inode_fields(
+                read_u32le(data, 0x90),
+                extra_field(0x94),
+            ))
+        } else {
+            None
+        };
+
         let mut checksum_base =
             Checksum::with_seed(ext4.0.superblock.checksum_seed);
         checksum_base.update_u32_le(index.get());
@@ -203,6 +240,10 @@ impl Inode {
                     file_type: FileType::try_from(mode).map_err(|_| {
                         CorruptKind::InodeFileType { inode: index, mode }
                     })?,
+                    atime,
+                    ctime,
+                    mtime,
+                    crtime,
                 },
                 flags: InodeFlags::from_bits_retain(i_flags),
                 checksum_base,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@ mod path;
 mod reader;
 mod resolve;
 mod superblock;
+mod timestamp;
 mod util;
 mod uuid;
 
@@ -167,6 +168,7 @@ pub use label::Label;
 pub use metadata::Metadata;
 pub use path::{Component, Components, Path, PathBuf, PathError};
 pub use reader::{Ext4Read, MemIoError};
+pub use timestamp::Timestamp;
 pub use uuid::Uuid;
 
 struct Ext4Inner {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -8,6 +8,7 @@
 
 use crate::file_type::FileType;
 use crate::inode::InodeMode;
+use crate::timestamp::Timestamp;
 
 /// Metadata information about a file.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -26,6 +27,18 @@ pub struct Metadata {
 
     /// Owner group ID.
     pub(crate) gid: u32,
+
+    /// Time of last access.
+    pub(crate) atime: Timestamp,
+
+    /// Time of last inode change.
+    pub(crate) ctime: Timestamp,
+
+    /// Time of last content modification.
+    pub(crate) mtime: Timestamp,
+
+    /// Time of creation. `None` for inodes too small to store it.
+    pub(crate) crtime: Option<Timestamp>,
 }
 
 impl Metadata {
@@ -90,5 +103,39 @@ impl Metadata {
     #[must_use]
     pub fn gid(&self) -> u32 {
         self.gid
+    }
+
+    /// Time of last access.
+    ///
+    /// Note that many systems are mounted with `noatime` or `relatime`, in
+    /// which case this is not updated on every read.
+    #[must_use]
+    pub fn atime(&self) -> Timestamp {
+        self.atime
+    }
+
+    /// Time the inode was last changed.
+    ///
+    /// This covers metadata changes such as permissions, in addition to
+    /// content changes.
+    #[must_use]
+    pub fn ctime(&self) -> Timestamp {
+        self.ctime
+    }
+
+    /// Time the file's contents were last modified.
+    #[must_use]
+    pub fn mtime(&self) -> Timestamp {
+        self.mtime
+    }
+
+    /// Time the file was created.
+    ///
+    /// Returns `None` when the inode is too small to store a creation time.
+    /// Only inodes larger than 128 bytes have this field, so file systems
+    /// created with the minimum inode size do not record it.
+    #[must_use]
+    pub fn crtime(&self) -> Option<Timestamp> {
+        self.crtime
     }
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -17,6 +17,19 @@ pub struct Timestamp {
 }
 
 impl Timestamp {
+    /// Create a timestamp from a second count and a nanosecond offset.
+    ///
+    /// Useful for comparing against a known time, and for exercising the edges of
+    /// a narrower time type downstream (NFSv3, for example, carries unsigned
+    /// 32-bit seconds and needs to clamp).
+    #[must_use]
+    pub fn new(seconds: i64, nanoseconds: u32) -> Self {
+        Self {
+            seconds,
+            nanoseconds,
+        }
+    }
+
     /// Decode a timestamp from its on-disk representation.
     ///
     /// `seconds_field` is one of the inode's 32-bit timestamp fields, which
@@ -69,6 +82,13 @@ impl Timestamp {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_new() {
+        let timestamp = Timestamp::new(-5, 42);
+        assert_eq!(timestamp.seconds(), -5);
+        assert_eq!(timestamp.nanoseconds(), 42);
+    }
 
     #[test]
     fn test_no_extra_field() {

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// A file timestamp, as stored in an inode.
+///
+/// Timestamps are relative to the Unix epoch (1970-01-01 00:00:00 UTC), and
+/// may be negative for earlier times.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Timestamp {
+    seconds: i64,
+    nanoseconds: u32,
+}
+
+impl Timestamp {
+    /// Decode a timestamp from its on-disk representation.
+    ///
+    /// `seconds_field` is one of the inode's 32-bit timestamp fields, which
+    /// holds a *signed* count of seconds since the Unix epoch.
+    ///
+    /// `extra_field` is the corresponding `*_extra` field, which only exists
+    /// in inodes larger than 128 bytes; pass zero when it is absent. Its low
+    /// two bits extend the seconds field past 2038, and its upper 30 bits
+    /// hold the nanoseconds.
+    pub(crate) fn from_inode_fields(
+        seconds_field: u32,
+        extra_field: u32,
+    ) -> Self {
+        // Reinterpret the field as signed without an `as` cast.
+        let base = i32::from_le_bytes(seconds_field.to_le_bytes());
+
+        // The low two bits are an unsigned extension of the seconds field.
+        let epoch_extension = i64::from(extra_field & 0x3) << 32;
+
+        Self {
+            // Both operands are bounded (a 32-bit base and a 34-bit
+            // extension), so this cannot actually saturate.
+            seconds: i64::from(base).saturating_add(epoch_extension),
+            nanoseconds: extra_field >> 2,
+        }
+    }
+
+    /// Seconds since the Unix epoch. Negative for times before 1970.
+    #[must_use]
+    pub fn seconds(self) -> i64 {
+        self.seconds
+    }
+
+    /// Nanoseconds within the second.
+    ///
+    /// This is zero for inodes that are too small to have the extra
+    /// timestamp fields (128-byte inodes), since they only store
+    /// second-granularity times.
+    ///
+    /// The on-disk field is 30 bits wide, so a corrupt file system can
+    /// produce a value larger than `999_999_999`. The value is returned as
+    /// stored rather than clamped, so callers converting to another time
+    /// type should handle that case.
+    #[must_use]
+    pub fn nanoseconds(self) -> u32 {
+        self.nanoseconds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_extra_field() {
+        // 128-byte inodes have no `*_extra` field, so nanoseconds are zero.
+        let timestamp = Timestamp::from_inode_fields(1_765_162_262, 0);
+        assert_eq!(timestamp.seconds(), 1_765_162_262);
+        assert_eq!(timestamp.nanoseconds(), 0);
+    }
+
+    #[test]
+    fn test_nanoseconds() {
+        // The upper 30 bits of the extra field hold nanoseconds.
+        let timestamp = Timestamp::from_inode_fields(0x6788_7c01, 0x7c71_5ecc);
+        assert_eq!(timestamp.seconds(), 1_736_997_889);
+        assert_eq!(timestamp.nanoseconds(), 521_951_155);
+    }
+
+    #[test]
+    fn test_epoch_extension() {
+        // The low two bits of the extra field extend the seconds field, so
+        // that times past 2038 are representable.
+        let base = 0u32;
+        assert_eq!(Timestamp::from_inode_fields(base, 0).seconds(), 0);
+        assert_eq!(Timestamp::from_inode_fields(base, 1).seconds(), 1 << 32);
+        assert_eq!(Timestamp::from_inode_fields(base, 2).seconds(), 2i64 << 32);
+        assert_eq!(Timestamp::from_inode_fields(base, 3).seconds(), 3i64 << 32);
+
+        // A negative base combined with an epoch extension: this is how
+        // dates after 2038 are stored, since the base wraps to negative.
+        let past_2038 = Timestamp::from_inode_fields(0x8000_0000, 1);
+        assert_eq!(past_2038.seconds(), i64::from(i32::MIN) + (1 << 32));
+        assert_eq!(past_2038.seconds(), 2_147_483_648);
+    }
+
+    #[test]
+    fn test_negative_seconds() {
+        // Times before 1970 are stored as a negative base with no epoch
+        // extension bits.
+        let timestamp = Timestamp::from_inode_fields(0xffff_ffff, 0);
+        assert_eq!(timestamp.seconds(), -1);
+    }
+
+    #[test]
+    fn test_out_of_range_nanoseconds() {
+        // A corrupt file system can store more than one second worth of
+        // nanoseconds. The value is passed through as stored.
+        let timestamp = Timestamp::from_inode_fields(0, u32::MAX);
+        assert_eq!(timestamp.nanoseconds(), u32::MAX >> 2);
+        assert!(timestamp.nanoseconds() > 999_999_999);
+    }
+}

--- a/tests/integration/ext3.rs
+++ b/tests/integration/ext3.rs
@@ -23,6 +23,25 @@ fn test_read_small_inode() {
     assert_eq!(entry.file_name(), ".");
 }
 
+/// Test timestamps from a filesystem with 128-byte inodes, which have no
+/// room for the `*_extra` fields that hold nanoseconds and the creation
+/// time.
+#[test]
+fn test_small_inode_timestamps() {
+    let fs = load_ext3();
+
+    // Obtained independently with `debugfs -R "stat /medium_dir/0"`, which
+    // prints `mtime: 0x69363d16` with no extra field for this inode.
+    let metadata = fs.metadata("/medium_dir/0").unwrap();
+    assert_eq!(metadata.mtime().seconds(), 1_765_162_262);
+    assert_eq!(metadata.mtime().nanoseconds(), 0);
+    assert_eq!(metadata.atime(), metadata.mtime());
+    assert_eq!(metadata.ctime(), metadata.mtime());
+
+    // 128-byte inodes have no creation time at all.
+    assert_eq!(metadata.crtime(), None);
+}
+
 /// Test reading files from an htree directory that uses TEA hashes.
 #[test]
 fn test_tea_htree() {

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -300,6 +300,32 @@ fn test_metadata_uid_gid() {
 }
 
 #[test]
+fn test_metadata_timestamps() {
+    let fs = load_test_disk1();
+
+    // The expected values in this test were obtained independently, with
+    // `debugfs -R "stat <path>" test_disk1.bin` from e2fsprogs, which prints
+    // each timestamp as `<seconds>:<extra>` in hex.
+
+    // ctime: 0x67887c01:7c715ecc
+    let metadata = fs.metadata("/small_file").unwrap();
+    assert_eq!(metadata.mtime().seconds(), 1_736_997_889);
+    assert_eq!(metadata.mtime().nanoseconds(), 521_951_155);
+
+    // This disk was created in a single pass, so all four timestamps match.
+    assert_eq!(metadata.atime(), metadata.mtime());
+    assert_eq!(metadata.ctime(), metadata.mtime());
+    assert_eq!(metadata.crtime(), Some(metadata.mtime()));
+
+    // A different file has different nanoseconds, so the nanosecond part is
+    // really coming from the inode rather than a shared value.
+    // ctime: 0x67887c01:c2fc4008
+    let metadata = fs.metadata("/holes").unwrap();
+    assert_eq!(metadata.mtime().seconds(), 1_736_997_889);
+    assert_eq!(metadata.mtime().nanoseconds(), 817_827_842);
+}
+
+#[test]
 fn test_direntry_debug() {
     let fs = load_test_disk1();
     let entry = fs


### PR DESCRIPTION
ext4 stores `atime`, `ctime` and `mtime` as signed 32-bit second counts, each with an optional `*_extra` field carrying 30 bits of nanoseconds plus two bits that extend the epoch past 2038. Inodes larger than 128 bytes additionally store a creation time.

None of this was reachable from the public API, so a caller cannot report file times at all — which is a hard blocker when exposing an ext4 volume through a file system server, and a visible gap for anything that wants to behave like `std::fs`.

### What this adds

- A `Timestamp` type: seconds since the Unix epoch (`i64`, may be negative) plus nanoseconds.
- `Metadata::atime`, `Metadata::ctime`, `Metadata::mtime`.
- `Metadata::crtime`, returning `Option<Timestamp>` because 128-byte inodes have no room for it.

Field presence follows the kernel's `EXT4_FITS_IN_INODE` rule: a field exists only if `i_extra_isize` says the inode is large enough. When the extra fields are absent, nanoseconds are zero and `crtime` is `None`.

### Two deliberate choices, both open to discussion

1. **No `SystemTime` conversion.** It would need a `std`-gated impl, and it would have to decide what to do about a corrupt file system storing more than `999_999_999` nanoseconds (the on-disk field is 30 bits wide) as well as about `SystemTime`'s panicking `Add`. Keeping `Timestamp` to two accessors leaves the crate `no_std` and avoids making that call inside a `From` impl. Documented that the raw nanosecond value is returned as stored.
2. **`crtime` is `Option` rather than defaulting to zero**, so callers can tell "created at the epoch" from "not recorded".

### Testing

`cargo test`, `cargo clippy --workspace` and `cargo fmt --check` are clean (the one pre-existing `arithmetic_side_effects` warning in `block_cache.rs` is untouched).

Unit tests cover the decoding rules directly: epoch extension bits, a negative base, a missing extra field, and out-of-range nanoseconds.

Integration test values were obtained independently with `debugfs -R "stat <path>"` from e2fsprogs — not from this implementation. They cover both paths:

- `test_disk1` (256-byte inodes): exact seconds *and* nanoseconds, with two different files asserted so the nanosecond part is provably per-inode rather than a shared constant.
- `test_disk_ext3` (128-byte inodes): nanoseconds are zero and `crtime` is `None`.

### Note

I have not signed the Google CLA yet. Happy to do that if you are interested in the change.