### PR TITLE
Report a short block map instead of panicking

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -308,6 +308,9 @@ pub(crate) enum CorruptKind {
     /// The number of blocks in a file exceeds 2^32.
     TooManyBlocksInFile,
 
+    /// A file's block map ended before the size recorded in its inode.
+    FileTruncated(InodeIndex),
+
     /// An extent's magic is invalid.
     ExtentMagic(InodeIndex),
 
@@ -494,6 +497,10 @@ impl Display for CorruptKind {
                 write!(f, "inode {inode} has an invalid symlink path")
             }
             Self::TooManyBlocksInFile => write!(f, "too many blocks in file"),
+            Self::FileTruncated(inode) => write!(
+                f,
+                "inode {inode} has fewer blocks than its size requires"
+            ),
             Self::ExtentMagic(inode) => {
                 write!(f, "extent in inode {inode} has invalid magic")
             }

--- a/src/file.rs
+++ b/src/file.rs
@@ -8,7 +8,7 @@
 
 use crate::Ext4;
 use crate::block_index::FsBlockIndex;
-use crate::error::Ext4Error;
+use crate::error::{CorruptKind, Ext4Error};
 use crate::inode::Inode;
 use crate::iters::file_blocks::FileBlocks;
 use crate::metadata::Metadata;
@@ -126,10 +126,25 @@ impl File {
         let block_index = if let Some(block_index) = self.block_index {
             block_index
         } else {
-            // OK to unwrap: already checked that the position is not at
-            // the end of the file, so there must be at least one more
-            // block to read.
-            let block_index = self.file_blocks.next().unwrap()?;
+            // The position is not at the end of the file, so the size
+            // says there is another block to read -- but the block map
+            // may disagree, in two ways that both reach here:
+            //
+            // * A corrupt inode can record a size larger than its block
+            //   map covers, so the iterator runs out early.
+            //
+            // * A block iterator that already yielded an error stops
+            //   yielding items (`impl_result_iter!` latches `is_done`),
+            //   while `position` was not advanced because the error
+            //   returned before the update. A caller that retries the
+            //   same read then arrives here with an exhausted iterator.
+            //
+            // Neither is a bug in this crate, so neither should abort
+            // the process: both are corruption to report.
+            let Some(block_index) = self.file_blocks.next() else {
+                return Err(CorruptKind::FileTruncated(self.inode.index).into());
+            };
+            let block_index = block_index?;
 
             self.block_index = Some(block_index);
 
@@ -269,5 +284,38 @@ impl Seek for File {
         self.seek_to(pos)?;
 
         Ok(self.position)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use crate::test_util::load_test_disk1;
+
+    /// A file whose inode records more bytes than its block map covers must
+    /// report corruption, not panic.
+    ///
+    /// The same code path is reached without any corruption on disk: a block
+    /// iterator that has already yielded an error stops yielding items, while
+    /// `position` was not advanced (the error returns before the update). A
+    /// caller that retries the same read then finds the iterator exhausted.
+    #[test]
+    fn read_bytes_reports_a_short_block_map() {
+        let fs = load_test_disk1();
+        let mut file = fs.open("/empty_file").unwrap();
+
+        // Claim a size the (empty) block map cannot satisfy.
+        file.inode.metadata.size_in_bytes = 4096;
+
+        let mut buf = [0u8; 512];
+        assert!(matches!(
+            file.read_bytes(&mut buf),
+            Err(Ext4Error::Corrupt(_))
+        ));
+        // And it stays an error rather than becoming a panic on retry.
+        assert!(matches!(
+            file.read_bytes(&mut buf),
+            Err(Ext4Error::Corrupt(_))
+        ));
     }
 }


### PR DESCRIPTION
`File::read_bytes` unwraps `FileBlocks::next()`, with the reasoning that the position is not at the end of the file, so another block must exist:

```rust
// OK to unwrap: already checked that the position is not at
// the end of the file, so there must be at least one more
// block to read.
let block_index = self.file_blocks.next().unwrap()?;
```

A file's recorded size and its block map can disagree, and there are two ways to reach that unwrap with `None`:

1. **A corrupt inode records a size larger than its block map covers.** The iterator runs out early and the process aborts, rather than returning `Corrupt` the way every other corruption in this crate does.

2. **The iterator already yielded an error.** `impl_result_iter!` latches `is_done` (`src/iters.rs`), so every later `next()` is `None` — while `position` was *not* advanced, because the error returns before the position update. A caller that retries the same offset then finds an exhausted iterator and panics. Nothing on disk has to be malformed for this: an unreadable indirect block, i.e. one bad sector, is enough.

The second case is how I hit it. I maintain a read-only ext4 reader for macOS that serves the filesystem over loopback NFS; NFS clients retry a failed read. On an ext2-style image whose `i_block[IND]` points past the end of the device:

```
read #1 at 49152: Err(IO)
thread 'ext4-worker' panicked at src/file.rs:132:55:
called `Option::unwrap()` on a `None` value
read #2 at 49152: Err(IO)
read #3 at 0    : Err(IO)   <-- healthy block; the worker thread is dead
```

The panic killed the thread that owned the `Ext4`, so every subsequent request failed — including reads of undamaged files.

This PR returns a new `CorruptKind::FileTruncated(inode)` instead of unwrapping. The added test doctors a size to be larger than the block map and asserts both the first read and the retry return `Corrupt`; without the change the first read panics.

`CorruptKind` is `pub(crate)`, so the new variant is not a public API change. `cargo test --all-features`, `cargo clippy --all-features --all-targets` and `cargo fmt --check` are clean (the three clippy `arithmetic_side_effects` warnings in `block_cache`/`dir_htree`/`journal::superblock` test code predate this change).

Note on the CLA: as with #575 and #576, the `cla/google` check is outstanding on my side. I am sorting that out and will confirm here once it passes.
