### PR TITLE
Expose the inode number recorded in a directory entry

### DIFF
--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -622,6 +622,9 @@ mod tests {
         assert!(name.as_str().is_err());
     }
 
+    // `test_util` loads a real file system image from disk, which the crate
+    // only builds with `std`.
+    #[cfg(feature = "std")]
     #[test]
     fn test_dir_entry_inode() {
         let fs = crate::test_util::load_test_disk1();

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -332,7 +332,6 @@ impl DirEntry {
         self.path.join(self.name.as_bytes())
     }
 
-    /// Get the entry's file type.
     /// Number of the inode this entry points to, as recorded in the
     /// directory entry itself.
     ///
@@ -347,6 +346,7 @@ impl DirEntry {
         self.inode.get()
     }
 
+    /// Get the entry's file type.
     pub fn file_type(&self) -> Result<FileType, Ext4Error> {
         // Currently this function cannot fail, but return a `Result` to
         // preserve that option for the future (may be needed for

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -333,6 +333,20 @@ impl DirEntry {
     }
 
     /// Get the entry's file type.
+    /// Number of the inode this entry points to, as recorded in the
+    /// directory entry itself.
+    ///
+    /// Unlike [`metadata`][Self::metadata], this needs no additional
+    /// read: the number is part of the directory data that has already
+    /// been loaded. That makes it usable where the inode itself cannot
+    /// be read -- a damaged filesystem -- and where only the identity of
+    /// an entry is needed, for example to detect a directory cycle while
+    /// walking a tree.
+    #[must_use]
+    pub fn inode(&self) -> u32 {
+        self.inode.get()
+    }
+
     pub fn file_type(&self) -> Result<FileType, Ext4Error> {
         // Currently this function cannot fail, but return a `Result` to
         // preserve that option for the future (may be needed for
@@ -606,5 +620,40 @@ mod tests {
 
         let name = DirEntryName([0xc3, 0x28].as_slice());
         assert!(name.as_str().is_err());
+    }
+
+    #[test]
+    fn test_dir_entry_inode() {
+        let fs = crate::test_util::load_test_disk1();
+        let entries: Vec<_> = fs
+            .read_dir("/")
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .collect();
+
+        let inode_of = |name: &str| -> u32 {
+            entries
+                .iter()
+                .find(|entry| entry.file_name().as_str().unwrap() == name)
+                .unwrap()
+                .inode()
+        };
+
+        // The root directory is always inode 2, and its "." entry points at
+        // itself. The root's parent is the root, so ".." matches too.
+        assert_eq!(inode_of("."), 2);
+        assert_eq!(inode_of(".."), 2);
+
+        // Every other entry points somewhere, and to something other than the
+        // root -- an inode of zero would mean an unused entry, which the
+        // iterator skips.
+        for entry in &entries {
+            let name = entry.file_name();
+            let name = name.as_str().unwrap();
+            assert_ne!(entry.inode(), 0, "{name}");
+            if name != "." && name != ".." {
+                assert_ne!(entry.inode(), 2, "{name}");
+            }
+        }
     }
 }


### PR DESCRIPTION
`DirEntry` already reads and validates the inode number it points to (`from_bytes` rejects a zero one and keeps `points_to_inode`), but there is no way to read it. The only route to an inode number is `metadata()`, which reads the inode itself.

That costs a read where none is needed, and it fails where the number is still useful:

- **Cycle detection while walking a tree** needs entry identity and nothing else. Paying an inode read per entry for it is wasteful, and on a damaged filesystem the read can fail on exactly the entry whose identity would have stopped an unbounded recursion.

- **A server exposing a directory listing** (NFS, FUSE) needs a stable identity per entry in order to page. If one entry's inode cannot be read, today's options are to drop that entry — which shifts every later entry's position and silently breaks pagination for a client holding a cookie — or to fail the whole directory. Keeping the entry with the identity from the directory data solves it.

That second case is my own: I maintain a read-only ext4 reader for macOS that serves the filesystem over loopback NFS, and this is the last thing forcing it to choose between a shortened listing and a failed one when a single inode read flakes.

`inode()` returns the number stored in the directory entry, so it needs no read and works when the inode is unreadable. It is a `u32` to match the on-disk width and `Metadata::inode` in #575.

The test asserts the root's `.` and `..` both report inode 2 on `test_disk1` and that no other entry does, so it pins the value against something independent of the accessor itself.

`cargo test --all-features`, `cargo clippy --all-features --all-targets` and `cargo fmt --check` are clean (the three pre-existing `arithmetic_side_effects` warnings in test code are unrelated).

Note on the CLA: as with #575, #576 and #577, the `cla/google` check is outstanding on my side. I am sorting that out and will confirm once it passes.