### PR TITLE
Bound a symlink target by the maximum path length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fixed a symlink whose inode records an impossible size being allocated in
+  full before the target is read. `Ext4Error::PathTooLong` is returned instead.
 * MSRV increased to `1.85`.
 * Improved error messages for various directory entry corruption errors.
 * Changed the `Debug` impls for stringish types (such as `DirEntryName`

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -13,6 +13,7 @@ use crate::error::{CorruptKind, Ext4Error};
 use crate::file_type::FileType;
 use crate::metadata::Metadata;
 use crate::path::PathBuf;
+use crate::resolve::MAX_PATH_LEN;
 use crate::util::{
     read_u16le, read_u32le, u32_from_hilo, u64_from_hilo, usize_from_u32,
 };
@@ -272,6 +273,17 @@ impl Inode {
             return Err(CorruptKind::SymlinkTarget(self.index).into());
         }
 
+        // A target longer than the maximum path length cannot be resolved, and
+        // the size comes from the inode rather than from the blocks the inode
+        // actually has: nothing cross-checks it, so a corrupt or hostile
+        // filesystem can claim any 64-bit value. Without this check the read
+        // below allocates that much before the target is looked at, which for a
+        // large enough claim aborts the process instead of returning an error.
+        // Linux caps a symlink target at PATH_MAX for the same reason.
+        if self.metadata.size_in_bytes > MAX_PATH_LEN as u64 {
+            return Err(Ext4Error::PathTooLong);
+        }
+
         // Symlink targets of up to 59 bytes are stored inline. Longer
         // targets are stored as regular file data.
         const MAX_INLINE_SYMLINK_LEN: u64 = 59;
@@ -360,4 +372,42 @@ fn get_inode_location(
             .map_err(|_| err())?;
 
     Ok((block_index, offset_within_block))
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use crate::path::Path;
+    use crate::resolve::{FollowSymlinks, resolve_path};
+    use crate::test_util::load_test_disk1;
+
+    /// A symlink whose inode claims an impossible size is an error rather than
+    /// an allocation of that size.
+    #[test]
+    fn test_symlink_target_too_long() {
+        let fs = load_test_disk1();
+        let (mut inode, _) = resolve_path(
+            &fs,
+            Path::new("/dir1/dir2/sym_abs"),
+            FollowSymlinks::ExcludeFinalComponent,
+        )
+        .unwrap();
+        assert!(inode.metadata.is_symlink());
+
+        // Eight terabytes, which no symlink target can be and which the read
+        // path would otherwise allocate.
+        inode.metadata.size_in_bytes = 8 * 1024 * 1024 * 1024 * 1024;
+        assert!(matches!(
+            inode.symlink_target(&fs),
+            Err(Ext4Error::PathTooLong)
+        ));
+
+        // The boundary itself is still accepted, so the check does not narrow
+        // what the library can read.
+        inode.metadata.size_in_bytes = MAX_PATH_LEN as u64;
+        assert!(!matches!(
+            inode.symlink_target(&fs),
+            Err(Ext4Error::PathTooLong)
+        ));
+    }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -27,6 +27,11 @@ pub(crate) enum FollowSymlinks {
     ExcludeFinalComponent,
 }
 
+/// Maximum path length in bytes. In general this library does not enforce a
+/// path length limit, but during path resolution the length can grow quite a
+/// bit due to symlinks.
+pub(crate) const MAX_PATH_LEN: usize = 4096;
+
 /// Resolve a path to get both the inode it points to and a
 /// canonicalized path representation:
 ///   * Path separators deduplicated ("a//" becomes "a/").
@@ -58,11 +63,6 @@ pub(crate) enum FollowSymlinks {
 /// This function panics if path resolution takes over 1000
 /// iterations. This should never occur in practice due to other
 /// restrictions, this is just a hedge against unforeseen bugs.
-/// Maximum path length in bytes. In general this library does not enforce a
-/// path length limit, but during path resolution the length can grow quite a
-/// bit due to symlinks.
-pub(crate) const MAX_PATH_LEN: usize = 4096;
-
 pub(crate) fn resolve_path(
     fs: &Ext4,
     path: Path<'_>,

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -58,6 +58,11 @@ pub(crate) enum FollowSymlinks {
 /// This function panics if path resolution takes over 1000
 /// iterations. This should never occur in practice due to other
 /// restrictions, this is just a hedge against unforeseen bugs.
+/// Maximum path length in bytes. In general this library does not enforce a
+/// path length limit, but during path resolution the length can grow quite a
+/// bit due to symlinks.
+pub(crate) const MAX_PATH_LEN: usize = 4096;
+
 pub(crate) fn resolve_path(
     fs: &Ext4,
     path: Path<'_>,
@@ -66,10 +71,6 @@ pub(crate) fn resolve_path(
     // Maximum number of symlinks to resolve (for the whole path, not
     // individual components).
     const MAX_SYMLINKS: usize = 40;
-    // Maximum path length in bytes. In general this library does not
-    // enforce a path length limit, but during path resolution the
-    // length can grow quite a bit due to symlinks.
-    const MAX_PATH_LEN: usize = 4096;
     // Maximum number of iterations. This limit should never be reached
     // in practice, this is just to guard against unknown bugs that
     // could cause an infinite loop.


### PR DESCRIPTION
`Inode::symlink_target` allocates `size_in_bytes` before it looks at the target, and that size comes from the inode rather than from the blocks the inode actually has. Nothing cross-checks it, so a corrupt or hostile filesystem can claim any 64-bit value: a symlink claiming 8 TiB aborts the process on the allocation rather than returning an error.

Measured against a fixture image before the change (2 GiB claimed): reading through a path containing such a symlink took the process from 7 MiB to 2154 MiB RSS; at larger sizes it is killed outright. It is reachable from `open`, `read_dir` and `metadata` as well as `read_link`, because `resolve_path` calls `symlink_target` for any symlink component.

A target longer than the maximum path length cannot be resolved anyway (`resolve_path` already returns `PathTooLong` for one), and Linux caps a symlink target at PATH_MAX for the same reason, so the size is checked before the read. `MAX_PATH_LEN` moves out of `resolve_path`'s body so both places name one limit.

The test forces the size on a real symlink inode from `test_disk1` and checks both sides of the boundary: 8 TiB is refused, and PATH_MAX itself is still accepted, so nothing the library could read before is refused now.

Found while reading images from a failing 4 TB disk, where the size field is one of the first things to go.

Written with AI assistance; I review every line and run the suite before sending anything.