### PR TITLE
Read the meta_bg layout instead of refusing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added `Metadata::inode`, `Metadata::nlink`, and `Metadata::blocks` to
+  expose the inode index, hard link count, and allocated 512-byte sector
+  count.
 * MSRV increased to `1.85`.
 * Improved error messages for various directory entry corruption errors.
 * Changed the `Debug` impls for stringish types (such as `DirEntryName`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fixed a symlink whose inode records an impossible size being allocated in
+  full before the target is read. `Ext4Error::PathTooLong` is returned instead.
 * MSRV increased to `1.85`.
 * Improved error messages for various directory entry corruption errors.
 * Changed the `Debug` impls for stringish types (such as `DirEntryName`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Added `Metadata::atime`, `Metadata::ctime`, `Metadata::mtime`, and
+  `Metadata::crtime`, along with the `Timestamp` type they return.
 * MSRV increased to `1.85`.
 * Improved error messages for various directory entry corruption errors.
 * Changed the `Debug` impls for stringish types (such as `DirEntryName`

--- a/src/block_group.rs
+++ b/src/block_group.rs
@@ -52,23 +52,75 @@ impl BlockGroupDescriptor {
         }
     }
 
+    /// Whether a block group holds a copy of the superblock, under `SPARSE_SUPER`.
+    ///
+    /// Groups 0 and 1, and every power of 3, 5 and 7. `META_BLOCK_GROUPS` does not change this:
+    /// that feature moves the *descriptor* blocks and leaves the superblock backups where
+    /// `SPARSE_SUPER` puts them.
+    fn group_has_superblock(group: u32) -> bool {
+        if group <= 1 {
+            return true;
+        }
+        [3u32, 5, 7].iter().any(|base| {
+            let mut power = *base;
+            loop {
+                if power == group {
+                    return true;
+                }
+                match power.checked_mul(*base) {
+                    Some(next) if next <= group => power = next,
+                    _ => return false,
+                }
+            }
+        })
+    }
+
     /// Map from a block group descriptor index to the absolute byte
     /// within the file where the descriptor starts.
+    ///
+    /// Two layouts. Without `META_BLOCK_GROUPS` the descriptor table is one run beginning in the
+    /// block after the superblock. With it, the table is cut into one block per meta block group —
+    /// `block_size / descriptor_size` groups' worth — and each such block is stored inside the
+    /// groups it describes rather than at the start of the filesystem. The kernel's documentation
+    /// states the placement: "a single block group descriptor block is placed at the beginning of
+    /// the first, second, and last block groups in a meta-block group". This returns the first of
+    /// those, which is the copy e2fsprogs treats as primary.
+    ///
+    /// The feature exists because the contiguous table has to fit in group 0, which stops being
+    /// possible above about 1TB with a 1KiB block size — `mke2fs` switches to this layout there.
     fn get_start_byte(
         sb: &Superblock,
         bgd_index: BlockGroupIndex,
     ) -> Option<u64> {
-        let bgd_start_block: u32 = if sb.block_size == 1024 { 2 } else { 1 };
         let bgd_per_block = sb
             .block_size
             .to_u32()
             .checked_div(u32::from(sb.block_group_descriptor_size))?;
-        let block_index = bgd_start_block
-            .checked_add(bgd_index.checked_div(bgd_per_block)?)?;
+        let table_block = bgd_index.checked_div(bgd_per_block)?;
         let offset_within_block = (bgd_index.checked_rem(bgd_per_block)?)
             .checked_mul(u32::from(sb.block_group_descriptor_size))?;
 
-        u64::from(block_index)
+        let block_index: u64 = match sb.first_meta_block_group {
+            Some(first) if table_block >= first => {
+                // The meta block group's own block, at the start of the first group it describes,
+                // after that group's superblock backup where it has one.
+                let first_group = table_block.checked_mul(bgd_per_block)?;
+                let group_start = u64::from(sb.first_data_block).checked_add(
+                    u64::from(first_group)
+                        .checked_mul(u64::from(sb.blocks_per_group))?,
+                )?;
+                group_start.checked_add(u64::from(
+                    Self::group_has_superblock(first_group),
+                ))?
+            }
+            _ => {
+                let bgd_start_block: u32 =
+                    if sb.block_size == 1024 { 2 } else { 1 };
+                u64::from(bgd_start_block.checked_add(table_block)?)
+            }
+        };
+
+        block_index
             .checked_mul(sb.block_size.to_u64())?
             .checked_add(u64::from(offset_within_block))
     }
@@ -139,5 +191,116 @@ impl BlockGroupDescriptor {
         }
 
         Ok(block_group_descriptors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_size::BlockSize;
+    use crate::label::Label;
+    use crate::uuid::Uuid;
+    use core::num::NonZero;
+
+    /// A 1KiB-block, 64-bit filesystem of 128 block groups: eight meta block groups of sixteen.
+    fn meta_bg_superblock(
+        blocks_count: u64,
+        first_meta_block_group: Option<u32>,
+    ) -> Superblock {
+        Superblock {
+            block_size: BlockSize::from_superblock_value(0).unwrap(),
+            blocks_count,
+            inode_size: 256,
+            inodes_per_block_group: NonZero::new(2048).unwrap(),
+            block_group_descriptor_size: 64,
+            first_data_block: 1,
+            blocks_per_group: 8192,
+            first_meta_block_group,
+            num_block_groups: u32::try_from(
+                blocks_count.saturating_sub(1).div_ceil(8192),
+            )
+            .unwrap(),
+            incompatible_features: IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY
+                | IncompatibleFeatures::EXTENTS
+                | IncompatibleFeatures::IS_64BIT,
+            read_only_compatible_features:
+                ReadOnlyCompatibleFeatures::SPARSE_SUPERBLOCKS,
+            checksum_seed: 0,
+            htree_hash_seed: [0; 4],
+            journal_inode: None,
+            label: Label::new([0; 16]),
+            uuid: Uuid::new([0; 16]),
+        }
+    }
+
+    /// `META_BLOCK_GROUPS` stores each descriptor block inside the groups it describes.
+    ///
+    /// The numbers come from `dumpe2fs` on a filesystem built with
+    /// `mke2fs -t ext4 -O meta_bg,^resize_inode -b 1024 -F img 1048576`, which reports the
+    /// descriptor blocks at 2, 8194, 122881, 131073, 139265, 253953, 262145, 270337, …
+    #[test]
+    fn meta_block_group_descriptor_locations() {
+        let sb = meta_bg_superblock(1_048_576, Some(0));
+        assert_eq!(sb.num_block_groups, 128);
+
+        // Meta block group 0 covers groups 0..15, and its block is in group 0 after the primary
+        // superblock: block 2.
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&sb, 0),
+            Some(2 * 1024)
+        );
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&sb, 15),
+            Some(2 * 1024 + 15 * 64)
+        );
+
+        // Meta block group 1 covers 16..31, and group 16 carries no superblock backup, so its
+        // block is that group's first: 131073.
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&sb, 16),
+            Some(131_073 * 1024)
+        );
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&sb, 31),
+            Some(131_073 * 1024 + 15 * 64)
+        );
+        // And meta block group 2.
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&sb, 32),
+            Some(262_145 * 1024)
+        );
+
+        // Without the feature the table is one run beginning after the superblock.
+        let old = meta_bg_superblock(1_048_576, None);
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&old, 0),
+            Some(2 * 1024)
+        );
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&old, 16),
+            Some(2 * 1024 + 16 * 64)
+        );
+
+        // `s_first_meta_bg` counts descriptor blocks, so blocks below it keep the old layout.
+        let mixed = meta_bg_superblock(1_048_576, Some(2));
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&mixed, 31),
+            Some(2 * 1024 + 31 * 64)
+        );
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&mixed, 32),
+            Some(262_145 * 1024)
+        );
+    }
+
+    /// The groups carrying a superblock backup are `SPARSE_SUPER`'s, which `META_BLOCK_GROUPS`
+    /// does not change — measured on the same filesystem, whose backups are in groups 0, 1, 3, 5,
+    /// 7, 9, 25, 27, 49, 81 and 125.
+    #[test]
+    fn superblock_backups_follow_sparse_super() {
+        let sparse: Vec<u32> = (0..128)
+            .filter(|g| BlockGroupDescriptor::group_has_superblock(*g))
+            .collect();
+        assert_eq!(sparse, [0, 1, 3, 5, 7, 9, 25, 27, 49, 81, 125]);
     }
 }

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -333,6 +333,20 @@ impl DirEntry {
     }
 
     /// Get the entry's file type.
+    /// Number of the inode this entry points to, as recorded in the
+    /// directory entry itself.
+    ///
+    /// Unlike [`metadata`][Self::metadata], this needs no additional
+    /// read: the number is part of the directory data that has already
+    /// been loaded. That makes it usable where the inode itself cannot
+    /// be read -- a damaged filesystem -- and where only the identity of
+    /// an entry is needed, for example to detect a directory cycle while
+    /// walking a tree.
+    #[must_use]
+    pub fn inode(&self) -> u32 {
+        self.inode.get()
+    }
+
     pub fn file_type(&self) -> Result<FileType, Ext4Error> {
         // Currently this function cannot fail, but return a `Result` to
         // preserve that option for the future (may be needed for
@@ -606,5 +620,40 @@ mod tests {
 
         let name = DirEntryName([0xc3, 0x28].as_slice());
         assert!(name.as_str().is_err());
+    }
+
+    #[test]
+    fn test_dir_entry_inode() {
+        let fs = crate::test_util::load_test_disk1();
+        let entries: Vec<_> = fs
+            .read_dir("/")
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .collect();
+
+        let inode_of = |name: &str| -> u32 {
+            entries
+                .iter()
+                .find(|entry| entry.file_name().as_str().unwrap() == name)
+                .unwrap()
+                .inode()
+        };
+
+        // The root directory is always inode 2, and its "." entry points at
+        // itself. The root's parent is the root, so ".." matches too.
+        assert_eq!(inode_of("."), 2);
+        assert_eq!(inode_of(".."), 2);
+
+        // Every other entry points somewhere, and to something other than the
+        // root -- an inode of zero would mean an unused entry, which the
+        // iterator skips.
+        for entry in &entries {
+            let name = entry.file_name();
+            let name = name.as_str().unwrap();
+            assert_ne!(entry.inode(), 0, "{name}");
+            if name != "." && name != ".." {
+                assert_ne!(entry.inode(), 2, "{name}");
+            }
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -308,6 +308,9 @@ pub(crate) enum CorruptKind {
     /// The number of blocks in a file exceeds 2^32.
     TooManyBlocksInFile,
 
+    /// A file's block map ended before the size recorded in its inode.
+    FileTruncated(InodeIndex),
+
     /// An extent's magic is invalid.
     ExtentMagic(InodeIndex),
 
@@ -494,6 +497,10 @@ impl Display for CorruptKind {
                 write!(f, "inode {inode} has an invalid symlink path")
             }
             Self::TooManyBlocksInFile => write!(f, "too many blocks in file"),
+            Self::FileTruncated(inode) => write!(
+                f,
+                "inode {inode} has fewer blocks than its size requires"
+            ),
             Self::ExtentMagic(inode) => {
                 write!(f, "extent in inode {inode} has invalid magic")
             }

--- a/src/file.rs
+++ b/src/file.rs
@@ -8,7 +8,7 @@
 
 use crate::Ext4;
 use crate::block_index::FsBlockIndex;
-use crate::error::Ext4Error;
+use crate::error::{CorruptKind, Ext4Error};
 use crate::inode::Inode;
 use crate::iters::file_blocks::FileBlocks;
 use crate::metadata::Metadata;
@@ -126,10 +126,25 @@ impl File {
         let block_index = if let Some(block_index) = self.block_index {
             block_index
         } else {
-            // OK to unwrap: already checked that the position is not at
-            // the end of the file, so there must be at least one more
-            // block to read.
-            let block_index = self.file_blocks.next().unwrap()?;
+            // The position is not at the end of the file, so the size
+            // says there is another block to read -- but the block map
+            // may disagree, in two ways that both reach here:
+            //
+            // * A corrupt inode can record a size larger than its block
+            //   map covers, so the iterator runs out early.
+            //
+            // * A block iterator that already yielded an error stops
+            //   yielding items (`impl_result_iter!` latches `is_done`),
+            //   while `position` was not advanced because the error
+            //   returned before the update. A caller that retries the
+            //   same read then arrives here with an exhausted iterator.
+            //
+            // Neither is a bug in this crate, so neither should abort
+            // the process: both are corruption to report.
+            let Some(block_index) = self.file_blocks.next() else {
+                return Err(CorruptKind::FileTruncated(self.inode.index).into());
+            };
+            let block_index = block_index?;
 
             self.block_index = Some(block_index);
 
@@ -269,5 +284,38 @@ impl Seek for File {
         self.seek_to(pos)?;
 
         Ok(self.position)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use crate::test_util::load_test_disk1;
+
+    /// A file whose inode records more bytes than its block map covers must
+    /// report corruption, not panic.
+    ///
+    /// The same code path is reached without any corruption on disk: a block
+    /// iterator that has already yielded an error stops yielding items, while
+    /// `position` was not advanced (the error returns before the update). A
+    /// caller that retries the same read then finds the iterator exhausted.
+    #[test]
+    fn read_bytes_reports_a_short_block_map() {
+        let fs = load_test_disk1();
+        let mut file = fs.open("/empty_file").unwrap();
+
+        // Claim a size the (empty) block map cannot satisfy.
+        file.inode.metadata.size_in_bytes = 4096;
+
+        let mut buf = [0u8; 512];
+        assert!(matches!(
+            file.read_bytes(&mut buf),
+            Err(Ext4Error::Corrupt(_))
+        ));
+        // And it stays an error rather than becoming a panic on retry.
+        assert!(matches!(
+            file.read_bytes(&mut buf),
+            Err(Ext4Error::Corrupt(_))
+        ));
     }
 }

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -13,6 +13,7 @@ use crate::error::{CorruptKind, Ext4Error};
 use crate::file_type::FileType;
 use crate::metadata::Metadata;
 use crate::path::PathBuf;
+use crate::timestamp::Timestamp;
 use crate::util::{
     read_u16le, read_u32le, u32_from_hilo, u64_from_hilo, usize_from_u32,
 };
@@ -152,6 +153,9 @@ impl Inode {
         let i_mode = read_u16le(data, 0x0);
         let i_uid = read_u16le(data, 0x2);
         let i_size_lo = read_u32le(data, 0x4);
+        let i_atime = read_u32le(data, 0x8);
+        let i_ctime = read_u32le(data, 0xc);
+        let i_mtime = read_u32le(data, 0x10);
         let i_gid = read_u16le(data, 0x18);
         let i_flags = read_u32le(data, 0x20);
         // OK to unwrap: already checked the length.
@@ -178,6 +182,39 @@ impl Inode {
         let checksum = u32_from_hilo(i_checksum_hi, l_i_checksum_lo);
         let mode = InodeMode::from_bits_retain(i_mode);
 
+        // The nanosecond parts of the timestamps, and the creation time,
+        // live past the 128-byte "good old" inode. They are only present if
+        // `i_extra_isize` says the inode is big enough, mirroring the
+        // kernel's `EXT4_FITS_IN_INODE` check.
+        let i_extra_isize = if data.len() >= 0x82 {
+            read_u16le(data, 0x80)
+        } else {
+            0
+        };
+        let extra_fields_end =
+            128usize.saturating_add(usize::from(i_extra_isize));
+        let extra_field = |offset: usize| -> u32 {
+            let end = offset.saturating_add(4);
+            if end <= extra_fields_end && end <= data.len() {
+                read_u32le(data, offset)
+            } else {
+                0
+            }
+        };
+        let has_crtime = 0x94 <= extra_fields_end && 0x94 <= data.len();
+
+        let atime = Timestamp::from_inode_fields(i_atime, extra_field(0x8c));
+        let ctime = Timestamp::from_inode_fields(i_ctime, extra_field(0x84));
+        let mtime = Timestamp::from_inode_fields(i_mtime, extra_field(0x88));
+        let crtime = if has_crtime {
+            Some(Timestamp::from_inode_fields(
+                read_u32le(data, 0x90),
+                extra_field(0x94),
+            ))
+        } else {
+            None
+        };
+
         let mut checksum_base =
             Checksum::with_seed(ext4.0.superblock.checksum_seed);
         checksum_base.update_u32_le(index.get());
@@ -203,6 +240,10 @@ impl Inode {
                     file_type: FileType::try_from(mode).map_err(|_| {
                         CorruptKind::InodeFileType { inode: index, mode }
                     })?,
+                    atime,
+                    ctime,
+                    mtime,
+                    crtime,
                 },
                 flags: InodeFlags::from_bits_retain(i_flags),
                 checksum_base,

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -153,11 +153,15 @@ impl Inode {
         let i_uid = read_u16le(data, 0x2);
         let i_size_lo = read_u32le(data, 0x4);
         let i_gid = read_u16le(data, 0x18);
+        let i_links_count = read_u16le(data, 0x1a);
+        let i_blocks_lo = read_u32le(data, 0x1c);
         let i_flags = read_u32le(data, 0x20);
         // OK to unwrap: already checked the length.
         let i_block = data.get(0x28..0x28 + Self::INLINE_DATA_LEN).unwrap();
         let i_generation = read_u32le(data, 0x64);
         let i_size_high = read_u32le(data, 0x6c);
+        // `l_i_blocks_high` is the first field of the `osd2` union at 0x74.
+        let l_i_blocks_high = read_u16le(data, 0x74);
         let l_i_uid_high = read_u16le(data, 0x74 + 0x4);
         let l_i_gid_high = read_u16le(data, 0x74 + 0x6);
         let (l_i_checksum_lo, i_checksum_hi) = if ext4.has_metadata_checksums()
@@ -177,6 +181,24 @@ impl Inode {
         let gid = u32_from_hilo(l_i_gid_high, i_gid);
         let checksum = u32_from_hilo(i_checksum_hi, l_i_checksum_lo);
         let mode = InodeMode::from_bits_retain(i_mode);
+        let flags = InodeFlags::from_bits_retain(i_flags);
+
+        // The `i_blocks` field normally counts 512-byte sectors, and the
+        // upper 16 bits in `l_i_blocks_high` are only meaningful when the
+        // file system has the `huge_file` feature. When that feature is
+        // present *and* the inode has the `HUGE_FILE` flag, the field
+        // counts file system blocks instead of sectors.
+        let raw_blocks = if ext4.has_huge_files() {
+            u64_from_hilo(u32::from(l_i_blocks_high), i_blocks_lo)
+        } else {
+            u64::from(i_blocks_lo)
+        };
+        let blocks = if flags.contains(InodeFlags::HUGE_FILE) {
+            raw_blocks
+                .saturating_mul(ext4.0.superblock.block_size.to_u64() / 512)
+        } else {
+            raw_blocks
+        };
 
         let mut checksum_base =
             Checksum::with_seed(ext4.0.superblock.checksum_seed);
@@ -203,8 +225,11 @@ impl Inode {
                     file_type: FileType::try_from(mode).map_err(|_| {
                         CorruptKind::InodeFileType { inode: index, mode }
                     })?,
+                    inode: index.get(),
+                    nlink: i_links_count,
+                    blocks,
                 },
-                flags: InodeFlags::from_bits_retain(i_flags),
+                flags,
                 checksum_base,
                 file_size_in_blocks,
             },

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -13,6 +13,7 @@ use crate::error::{CorruptKind, Ext4Error};
 use crate::file_type::FileType;
 use crate::metadata::Metadata;
 use crate::path::PathBuf;
+use crate::resolve::MAX_PATH_LEN;
 use crate::util::{
     read_u16le, read_u32le, u32_from_hilo, u64_from_hilo, usize_from_u32,
 };
@@ -272,6 +273,17 @@ impl Inode {
             return Err(CorruptKind::SymlinkTarget(self.index).into());
         }
 
+        // A target longer than the maximum path length cannot be resolved, and
+        // the size comes from the inode rather than from the blocks the inode
+        // actually has: nothing cross-checks it, so a corrupt or hostile
+        // filesystem can claim any 64-bit value. Without this check the read
+        // below allocates that much before the target is looked at, which for a
+        // large enough claim aborts the process instead of returning an error.
+        // Linux caps a symlink target at PATH_MAX for the same reason.
+        if self.metadata.size_in_bytes > MAX_PATH_LEN as u64 {
+            return Err(Ext4Error::PathTooLong);
+        }
+
         // Symlink targets of up to 59 bytes are stored inline. Longer
         // targets are stored as regular file data.
         const MAX_INLINE_SYMLINK_LEN: u64 = 59;
@@ -360,4 +372,42 @@ fn get_inode_location(
             .map_err(|_| err())?;
 
     Ok((block_index, offset_within_block))
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use crate::path::Path;
+    use crate::resolve::{FollowSymlinks, resolve_path};
+    use crate::test_util::load_test_disk1;
+
+    /// A symlink whose inode claims an impossible size is an error rather than
+    /// an allocation of that size.
+    #[test]
+    fn test_symlink_target_too_long() {
+        let fs = load_test_disk1();
+        let (mut inode, _) = resolve_path(
+            &fs,
+            Path::new("/dir1/dir2/sym_abs"),
+            FollowSymlinks::ExcludeFinalComponent,
+        )
+        .unwrap();
+        assert!(inode.metadata.is_symlink());
+
+        // Eight terabytes, which no symlink target can be and which the read
+        // path would otherwise allocate.
+        inode.metadata.size_in_bytes = 8 * 1024 * 1024 * 1024 * 1024;
+        assert!(matches!(
+            inode.symlink_target(&fs),
+            Err(Ext4Error::PathTooLong)
+        ));
+
+        // The boundary itself is still accepted, so the check does not narrow
+        // what the library can read.
+        inode.metadata.size_in_bytes = MAX_PATH_LEN as u64;
+        assert!(!matches!(
+            inode.symlink_target(&fs),
+            Err(Ext4Error::PathTooLong)
+        ));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@ mod path;
 mod reader;
 mod resolve;
 mod superblock;
+mod timestamp;
 mod util;
 mod uuid;
 
@@ -167,6 +168,7 @@ pub use label::Label;
 pub use metadata::Metadata;
 pub use path::{Component, Components, Path, PathBuf, PathError};
 pub use reader::{Ext4Read, MemIoError};
+pub use timestamp::Timestamp;
 pub use uuid::Uuid;
 
 struct Ext4Inner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,15 @@ impl Ext4 {
 
     /// Return true if the filesystem has metadata checksums enabled,
     /// false otherwise.
+    /// Whether the file system has the `huge_file` feature, which changes
+    /// how the inode's block count field is interpreted.
+    fn has_huge_files(&self) -> bool {
+        self.0
+            .superblock
+            .read_only_compatible_features
+            .contains(ReadOnlyCompatibleFeatures::HUGE_FILES)
+    }
+
     fn has_metadata_checksums(&self) -> bool {
         self.0
             .superblock

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -8,6 +8,7 @@
 
 use crate::file_type::FileType;
 use crate::inode::InodeMode;
+use crate::timestamp::Timestamp;
 
 /// Metadata information about a file.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -26,6 +27,18 @@ pub struct Metadata {
 
     /// Owner group ID.
     pub(crate) gid: u32,
+
+    /// Time of last access.
+    pub(crate) atime: Timestamp,
+
+    /// Time of last inode change.
+    pub(crate) ctime: Timestamp,
+
+    /// Time of last content modification.
+    pub(crate) mtime: Timestamp,
+
+    /// Time of creation. `None` for inodes too small to store it.
+    pub(crate) crtime: Option<Timestamp>,
 }
 
 impl Metadata {
@@ -90,5 +103,39 @@ impl Metadata {
     #[must_use]
     pub fn gid(&self) -> u32 {
         self.gid
+    }
+
+    /// Time of last access.
+    ///
+    /// Note that many systems are mounted with `noatime` or `relatime`, in
+    /// which case this is not updated on every read.
+    #[must_use]
+    pub fn atime(&self) -> Timestamp {
+        self.atime
+    }
+
+    /// Time the inode was last changed.
+    ///
+    /// This covers metadata changes such as permissions, in addition to
+    /// content changes.
+    #[must_use]
+    pub fn ctime(&self) -> Timestamp {
+        self.ctime
+    }
+
+    /// Time the file's contents were last modified.
+    #[must_use]
+    pub fn mtime(&self) -> Timestamp {
+        self.mtime
+    }
+
+    /// Time the file was created.
+    ///
+    /// Returns `None` when the inode is too small to store a creation time.
+    /// Only inodes larger than 128 bytes have this field, so file systems
+    /// created with the minimum inode size do not record it.
+    #[must_use]
+    pub fn crtime(&self) -> Option<Timestamp> {
+        self.crtime
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -26,6 +26,15 @@ pub struct Metadata {
 
     /// Owner group ID.
     pub(crate) gid: u32,
+
+    /// Index of the inode this metadata came from.
+    pub(crate) inode: u32,
+
+    /// Number of hard links to the file.
+    pub(crate) nlink: u16,
+
+    /// Number of 512-byte sectors allocated to the file.
+    pub(crate) blocks: u64,
 }
 
 impl Metadata {
@@ -90,5 +99,44 @@ impl Metadata {
     #[must_use]
     pub fn gid(&self) -> u32 {
         self.gid
+    }
+
+    /// Index of the inode this metadata came from.
+    ///
+    /// Inode indices start at one, so this is never zero. Two paths with
+    /// the same inode index refer to the same file (for example, hard
+    /// links).
+    #[must_use]
+    pub fn inode(&self) -> u32 {
+        self.inode
+    }
+
+    /// Number of hard links to the file.
+    ///
+    /// Note that when the file system has the `dir_nlink` feature and a
+    /// directory has more than 64,999 subdirectories, the on-disk link
+    /// count is set to one to indicate that the real count is unknown. In
+    /// that case this method returns one.
+    ///
+    /// See `st_nlink` in [inode(7)][inode] for more details.
+    ///
+    /// [inode]: https://www.man7.org/linux/man-pages/man7/inode.7.html
+    #[must_use]
+    pub fn nlink(&self) -> u16 {
+        self.nlink
+    }
+
+    /// Number of 512-byte sectors actually allocated to the file.
+    ///
+    /// This can be smaller than [`len`][Self::len] divided by 512 for a
+    /// sparse file, and larger for a file with indirect blocks or extent
+    /// tree nodes, since those count towards the allocation too.
+    ///
+    /// See `st_blocks` in [inode(7)][inode] for more details.
+    ///
+    /// [inode]: https://www.man7.org/linux/man-pages/man7/inode.7.html
+    #[must_use]
+    pub fn blocks(&self) -> u64 {
+        self.blocks
     }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -58,6 +58,11 @@ pub(crate) enum FollowSymlinks {
 /// This function panics if path resolution takes over 1000
 /// iterations. This should never occur in practice due to other
 /// restrictions, this is just a hedge against unforeseen bugs.
+/// Maximum path length in bytes. In general this library does not enforce a
+/// path length limit, but during path resolution the length can grow quite a
+/// bit due to symlinks.
+pub(crate) const MAX_PATH_LEN: usize = 4096;
+
 pub(crate) fn resolve_path(
     fs: &Ext4,
     path: Path<'_>,
@@ -66,10 +71,6 @@ pub(crate) fn resolve_path(
     // Maximum number of symlinks to resolve (for the whole path, not
     // individual components).
     const MAX_SYMLINKS: usize = 40;
-    // Maximum path length in bytes. In general this library does not
-    // enforce a path length limit, but during path resolution the
-    // length can grow quite a bit due to symlinks.
-    const MAX_PATH_LEN: usize = 4096;
     // Maximum number of iterations. This limit should never be reached
     // in practice, this is just to guard against unknown bugs that
     // could cause an infinite loop.

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -25,6 +25,16 @@ pub(crate) struct Superblock {
     pub(crate) inode_size: u16,
     pub(crate) inodes_per_block_group: NonZero<u32>,
     pub(crate) block_group_descriptor_size: u16,
+    /// First block of the filesystem's data: 1 when the block size is 1KiB, 0 otherwise.
+    pub(crate) first_data_block: u32,
+    pub(crate) blocks_per_group: u32,
+    /// With `META_BLOCK_GROUPS`, the first block-group-descriptor *block* stored in the
+    /// meta-block-group layout rather than in one run at the start of the filesystem. `None`
+    /// without the feature.
+    ///
+    /// Counted in descriptor blocks, not in block groups: e2fsprogs compares it against
+    /// `group / descriptors_per_block`.
+    pub(crate) first_meta_block_group: Option<u32>,
     pub(crate) num_block_groups: u32,
     pub(crate) incompatible_features: IncompatibleFeatures,
     pub(crate) read_only_compatible_features: ReadOnlyCompatibleFeatures,
@@ -55,6 +65,7 @@ impl Superblock {
         let s_blocks_per_group = read_u32le(bytes, 0x20);
         let s_inodes_per_group = read_u32le(bytes, 0x28);
         let s_magic = read_u16le(bytes, 0x38);
+        let s_first_meta_bg = read_u32le(bytes, 0x104);
         let s_inode_size = read_u16le(bytes, 0x58);
         let s_feature_compat = read_u32le(bytes, 0x5c);
         let s_feature_incompat = read_u32le(bytes, 0x60);
@@ -177,6 +188,15 @@ impl Superblock {
             inode_size: s_inode_size,
             inodes_per_block_group,
             block_group_descriptor_size,
+            first_data_block: s_first_data_block,
+            blocks_per_group: s_blocks_per_group,
+            first_meta_block_group: if incompatible_features
+                .contains(IncompatibleFeatures::META_BLOCK_GROUPS)
+            {
+                Some(s_first_meta_bg)
+            } else {
+                None
+            },
             num_block_groups,
             incompatible_features,
             read_only_compatible_features,
@@ -206,7 +226,6 @@ fn check_incompat_features(
     let required_features = IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY;
     let disallowed_features = IncompatibleFeatures::COMPRESSION
         | IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE
-        | IncompatibleFeatures::META_BLOCK_GROUPS
         | IncompatibleFeatures::MULTIPLE_MOUNT_PROTECTION
         | IncompatibleFeatures::LARGE_EXTENDED_ATTRIBUTES_IN_INODES
         | IncompatibleFeatures::DATA_IN_DIR_ENTRY
@@ -244,6 +263,9 @@ mod tests {
                 inode_size: 256,
                 inodes_per_block_group: NonZero::new(16).unwrap(),
                 block_group_descriptor_size: 64,
+                first_data_block: 1,
+                blocks_per_group: 8192,
+                first_meta_block_group: None,
                 num_block_groups: 1,
                 incompatible_features:
                     IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -17,6 +17,19 @@ pub struct Timestamp {
 }
 
 impl Timestamp {
+    /// Create a timestamp from a second count and a nanosecond offset.
+    ///
+    /// Useful for comparing against a known time, and for exercising the edges of
+    /// a narrower time type downstream (NFSv3, for example, carries unsigned
+    /// 32-bit seconds and needs to clamp).
+    #[must_use]
+    pub fn new(seconds: i64, nanoseconds: u32) -> Self {
+        Self {
+            seconds,
+            nanoseconds,
+        }
+    }
+
     /// Decode a timestamp from its on-disk representation.
     ///
     /// `seconds_field` is one of the inode's 32-bit timestamp fields, which
@@ -69,6 +82,13 @@ impl Timestamp {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_new() {
+        let timestamp = Timestamp::new(-5, 42);
+        assert_eq!(timestamp.seconds(), -5);
+        assert_eq!(timestamp.nanoseconds(), 42);
+    }
 
     #[test]
     fn test_no_extra_field() {

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// A file timestamp, as stored in an inode.
+///
+/// Timestamps are relative to the Unix epoch (1970-01-01 00:00:00 UTC), and
+/// may be negative for earlier times.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Timestamp {
+    seconds: i64,
+    nanoseconds: u32,
+}
+
+impl Timestamp {
+    /// Decode a timestamp from its on-disk representation.
+    ///
+    /// `seconds_field` is one of the inode's 32-bit timestamp fields, which
+    /// holds a *signed* count of seconds since the Unix epoch.
+    ///
+    /// `extra_field` is the corresponding `*_extra` field, which only exists
+    /// in inodes larger than 128 bytes; pass zero when it is absent. Its low
+    /// two bits extend the seconds field past 2038, and its upper 30 bits
+    /// hold the nanoseconds.
+    pub(crate) fn from_inode_fields(
+        seconds_field: u32,
+        extra_field: u32,
+    ) -> Self {
+        // Reinterpret the field as signed without an `as` cast.
+        let base = i32::from_le_bytes(seconds_field.to_le_bytes());
+
+        // The low two bits are an unsigned extension of the seconds field.
+        let epoch_extension = i64::from(extra_field & 0x3) << 32;
+
+        Self {
+            // Both operands are bounded (a 32-bit base and a 34-bit
+            // extension), so this cannot actually saturate.
+            seconds: i64::from(base).saturating_add(epoch_extension),
+            nanoseconds: extra_field >> 2,
+        }
+    }
+
+    /// Seconds since the Unix epoch. Negative for times before 1970.
+    #[must_use]
+    pub fn seconds(self) -> i64 {
+        self.seconds
+    }
+
+    /// Nanoseconds within the second.
+    ///
+    /// This is zero for inodes that are too small to have the extra
+    /// timestamp fields (128-byte inodes), since they only store
+    /// second-granularity times.
+    ///
+    /// The on-disk field is 30 bits wide, so a corrupt file system can
+    /// produce a value larger than `999_999_999`. The value is returned as
+    /// stored rather than clamped, so callers converting to another time
+    /// type should handle that case.
+    #[must_use]
+    pub fn nanoseconds(self) -> u32 {
+        self.nanoseconds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_no_extra_field() {
+        // 128-byte inodes have no `*_extra` field, so nanoseconds are zero.
+        let timestamp = Timestamp::from_inode_fields(1_765_162_262, 0);
+        assert_eq!(timestamp.seconds(), 1_765_162_262);
+        assert_eq!(timestamp.nanoseconds(), 0);
+    }
+
+    #[test]
+    fn test_nanoseconds() {
+        // The upper 30 bits of the extra field hold nanoseconds.
+        let timestamp = Timestamp::from_inode_fields(0x6788_7c01, 0x7c71_5ecc);
+        assert_eq!(timestamp.seconds(), 1_736_997_889);
+        assert_eq!(timestamp.nanoseconds(), 521_951_155);
+    }
+
+    #[test]
+    fn test_epoch_extension() {
+        // The low two bits of the extra field extend the seconds field, so
+        // that times past 2038 are representable.
+        let base = 0u32;
+        assert_eq!(Timestamp::from_inode_fields(base, 0).seconds(), 0);
+        assert_eq!(Timestamp::from_inode_fields(base, 1).seconds(), 1 << 32);
+        assert_eq!(Timestamp::from_inode_fields(base, 2).seconds(), 2i64 << 32);
+        assert_eq!(Timestamp::from_inode_fields(base, 3).seconds(), 3i64 << 32);
+
+        // A negative base combined with an epoch extension: this is how
+        // dates after 2038 are stored, since the base wraps to negative.
+        let past_2038 = Timestamp::from_inode_fields(0x8000_0000, 1);
+        assert_eq!(past_2038.seconds(), i64::from(i32::MIN) + (1 << 32));
+        assert_eq!(past_2038.seconds(), 2_147_483_648);
+    }
+
+    #[test]
+    fn test_negative_seconds() {
+        // Times before 1970 are stored as a negative base with no epoch
+        // extension bits.
+        let timestamp = Timestamp::from_inode_fields(0xffff_ffff, 0);
+        assert_eq!(timestamp.seconds(), -1);
+    }
+
+    #[test]
+    fn test_out_of_range_nanoseconds() {
+        // A corrupt file system can store more than one second worth of
+        // nanoseconds. The value is passed through as stored.
+        let timestamp = Timestamp::from_inode_fields(0, u32::MAX);
+        assert_eq!(timestamp.nanoseconds(), u32::MAX >> 2);
+        assert!(timestamp.nanoseconds() > 999_999_999);
+    }
+}

--- a/tests/integration/ext3.rs
+++ b/tests/integration/ext3.rs
@@ -23,6 +23,25 @@ fn test_read_small_inode() {
     assert_eq!(entry.file_name(), ".");
 }
 
+/// Test timestamps from a filesystem with 128-byte inodes, which have no
+/// room for the `*_extra` fields that hold nanoseconds and the creation
+/// time.
+#[test]
+fn test_small_inode_timestamps() {
+    let fs = load_ext3();
+
+    // Obtained independently with `debugfs -R "stat /medium_dir/0"`, which
+    // prints `mtime: 0x69363d16` with no extra field for this inode.
+    let metadata = fs.metadata("/medium_dir/0").unwrap();
+    assert_eq!(metadata.mtime().seconds(), 1_765_162_262);
+    assert_eq!(metadata.mtime().nanoseconds(), 0);
+    assert_eq!(metadata.atime(), metadata.mtime());
+    assert_eq!(metadata.ctime(), metadata.mtime());
+
+    // 128-byte inodes have no creation time at all.
+    assert_eq!(metadata.crtime(), None);
+}
+
 /// Test reading files from an htree directory that uses TEA hashes.
 #[test]
 fn test_tea_htree() {

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -300,6 +300,46 @@ fn test_metadata_uid_gid() {
 }
 
 #[test]
+fn test_metadata_inode_nlink_blocks() {
+    let fs = load_test_disk1();
+
+    // The expected values in this test were obtained independently, with
+    // `debugfs -R "stat <path>" test_disk1.bin` from e2fsprogs.
+
+    let metadata = fs.metadata("/small_file").unwrap();
+    assert_eq!(metadata.inode(), 14);
+    assert_eq!(metadata.nlink(), 1);
+    assert_eq!(metadata.blocks(), 2);
+
+    // A directory with one subdirectory has three links: its entry in the
+    // parent directory, its own ".", and the subdirectory's "..".
+    let metadata = fs.metadata("/dir1").unwrap();
+    assert_eq!(metadata.inode(), 2050);
+    assert_eq!(metadata.nlink(), 3);
+    assert_eq!(metadata.blocks(), 2);
+
+    // A sparse file allocates fewer sectors than its length implies.
+    let metadata = fs.metadata("/holes").unwrap();
+    assert_eq!(metadata.inode(), 11031);
+    assert_eq!(metadata.len(), 10240);
+    assert_eq!(metadata.blocks(), 8);
+    assert!(metadata.blocks() * 512 < metadata.len());
+
+    // Paths reached through a symlink resolve to the target's inode.
+    assert_eq!(
+        fs.metadata("/sym_simple").unwrap().inode(),
+        fs.metadata("/small_file").unwrap().inode()
+    );
+
+    // `symlink_metadata` does not follow the link, so it reports the
+    // symlink's own inode.
+    assert_ne!(
+        fs.symlink_metadata("/sym_simple").unwrap().inode(),
+        fs.metadata("/small_file").unwrap().inode()
+    );
+}
+
+#[test]
 fn test_direntry_debug() {
     let fs = load_test_disk1();
     let entry = fs

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -300,6 +300,32 @@ fn test_metadata_uid_gid() {
 }
 
 #[test]
+fn test_metadata_timestamps() {
+    let fs = load_test_disk1();
+
+    // The expected values in this test were obtained independently, with
+    // `debugfs -R "stat <path>" test_disk1.bin` from e2fsprogs, which prints
+    // each timestamp as `<seconds>:<extra>` in hex.
+
+    // ctime: 0x67887c01:7c715ecc
+    let metadata = fs.metadata("/small_file").unwrap();
+    assert_eq!(metadata.mtime().seconds(), 1_736_997_889);
+    assert_eq!(metadata.mtime().nanoseconds(), 521_951_155);
+
+    // This disk was created in a single pass, so all four timestamps match.
+    assert_eq!(metadata.atime(), metadata.mtime());
+    assert_eq!(metadata.ctime(), metadata.mtime());
+    assert_eq!(metadata.crtime(), Some(metadata.mtime()));
+
+    // A different file has different nanoseconds, so the nanosecond part is
+    // really coming from the inode rather than a shared value.
+    // ctime: 0x67887c01:c2fc4008
+    let metadata = fs.metadata("/holes").unwrap();
+    assert_eq!(metadata.mtime().seconds(), 1_736_997_889);
+    assert_eq!(metadata.mtime().nanoseconds(), 817_827_842);
+}
+
+#[test]
 fn test_direntry_debug() {
     let fs = load_test_disk1();
     let entry = fs


### PR DESCRIPTION
`META_BLOCK_GROUPS` is in `disallowed_features`, so a filesystem carrying it cannot be opened at all. Filesystems carrying it are ordinary rather than exotic: `mke2fs` switches to the layout on its own whenever the contiguous group descriptor table stops fitting in one block group, which happens above about 1 TB with a 1 KiB block size. A 1.5 TB ext4 made on Linux with `-b 1024` cannot be read by this crate today.

The feature cuts the descriptor table into one block per meta block group — `block_size / descriptor_size` groups' worth, so 16 groups at 1 KiB and 64 at 4 KiB — and stores each block inside the groups it describes instead of in one run at the start of the filesystem. The kernel documentation states the placement: "a single block group descriptor block is placed at the beginning of the first, second, and last block groups in a meta-block group". `get_start_byte` returns the first of those three, which is the copy e2fsprogs treats as primary, at that group's first block plus one where the group carries a superblock backup.

`s_first_meta_bg` is compared against the descriptor *block* index rather than the block group number, which is what e2fsprogs' own header says about the argument to `ext2fs_descriptor_block_loc2`: "not actually a group number but a block number offset within a group table". `mke2fs` writes 0 there when it enables the feature, so the whole table moves; a contiguous prefix is what `resize2fs` leaves behind when it grows a filesystem into the layout, and that is handled too.

Superblock backups are unaffected — they stay where `SPARSE_SUPER` puts them. This is worth stating because the kernel documentation describes the superblock and the descriptor block as being placed together, and on a real filesystem they are not. Measured on a 1.5 TB `mke2fs -b 1024` filesystem: 196,608 block groups, 36,864 of them holding a copy of a descriptor block, and 26 holding a superblock backup — groups 0, 1, and the powers of three, five and seven.

Verification: the rule reproduces the location `dumpe2fs` reports for every one of those 196,608 groups, and for both copies in every meta block group, with no mismatches. Two shapes were checked, because the edge is the short one — a filesystem of 120 groups has a final meta block group covering groups 112..127 with only 112..119 in existence, and `mke2fs` writes two copies there rather than three, without moving the third to the last group that does exist.

The tests' numbers come from `mke2fs -t ext4 -O meta_bg,^resize_inode -b 1024 -F img 1048576`. The `^resize_inode` is not optional: `mke2fs` refuses the pair outright — "The resize_inode and meta_bg features are not compatible. They can not be both enabled simultaneously."

`Superblock` gains `first_data_block` and `blocks_per_group`, both of which it already read and discarded, because the group base is what the new layout is expressed in.

Written with AI assistance; I review every line and run the suite before sending anything.
