### PR TITLE
Read the meta_bg layout instead of refusing it

### DIFF
--- a/src/block_group.rs
+++ b/src/block_group.rs
@@ -52,23 +52,75 @@ impl BlockGroupDescriptor {
         }
     }
 
+    /// Whether a block group holds a copy of the superblock, under `SPARSE_SUPER`.
+    ///
+    /// Groups 0 and 1, and every power of 3, 5 and 7. `META_BLOCK_GROUPS` does not change this:
+    /// that feature moves the *descriptor* blocks and leaves the superblock backups where
+    /// `SPARSE_SUPER` puts them.
+    fn group_has_superblock(group: u32) -> bool {
+        if group <= 1 {
+            return true;
+        }
+        [3u32, 5, 7].iter().any(|base| {
+            let mut power = *base;
+            loop {
+                if power == group {
+                    return true;
+                }
+                match power.checked_mul(*base) {
+                    Some(next) if next <= group => power = next,
+                    _ => return false,
+                }
+            }
+        })
+    }
+
     /// Map from a block group descriptor index to the absolute byte
     /// within the file where the descriptor starts.
+    ///
+    /// Two layouts. Without `META_BLOCK_GROUPS` the descriptor table is one run beginning in the
+    /// block after the superblock. With it, the table is cut into one block per meta block group —
+    /// `block_size / descriptor_size` groups' worth — and each such block is stored inside the
+    /// groups it describes rather than at the start of the filesystem. The kernel's documentation
+    /// states the placement: "a single block group descriptor block is placed at the beginning of
+    /// the first, second, and last block groups in a meta-block group". This returns the first of
+    /// those, which is the copy e2fsprogs treats as primary.
+    ///
+    /// The feature exists because the contiguous table has to fit in group 0, which stops being
+    /// possible above about 1TB with a 1KiB block size — `mke2fs` switches to this layout there.
     fn get_start_byte(
         sb: &Superblock,
         bgd_index: BlockGroupIndex,
     ) -> Option<u64> {
-        let bgd_start_block: u32 = if sb.block_size == 1024 { 2 } else { 1 };
         let bgd_per_block = sb
             .block_size
             .to_u32()
             .checked_div(u32::from(sb.block_group_descriptor_size))?;
-        let block_index = bgd_start_block
-            .checked_add(bgd_index.checked_div(bgd_per_block)?)?;
+        let table_block = bgd_index.checked_div(bgd_per_block)?;
         let offset_within_block = (bgd_index.checked_rem(bgd_per_block)?)
             .checked_mul(u32::from(sb.block_group_descriptor_size))?;
 
-        u64::from(block_index)
+        let block_index: u64 = match sb.first_meta_block_group {
+            Some(first) if table_block >= first => {
+                // The meta block group's own block, at the start of the first group it describes,
+                // after that group's superblock backup where it has one.
+                let first_group = table_block.checked_mul(bgd_per_block)?;
+                let group_start = u64::from(sb.first_data_block).checked_add(
+                    u64::from(first_group)
+                        .checked_mul(u64::from(sb.blocks_per_group))?,
+                )?;
+                group_start.checked_add(u64::from(
+                    Self::group_has_superblock(first_group),
+                ))?
+            }
+            _ => {
+                let bgd_start_block: u32 =
+                    if sb.block_size == 1024 { 2 } else { 1 };
+                u64::from(bgd_start_block.checked_add(table_block)?)
+            }
+        };
+
+        block_index
             .checked_mul(sb.block_size.to_u64())?
             .checked_add(u64::from(offset_within_block))
     }
@@ -139,5 +191,116 @@ impl BlockGroupDescriptor {
         }
 
         Ok(block_group_descriptors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_size::BlockSize;
+    use crate::label::Label;
+    use crate::uuid::Uuid;
+    use core::num::NonZero;
+
+    /// A 1KiB-block, 64-bit filesystem of 128 block groups: eight meta block groups of sixteen.
+    fn meta_bg_superblock(
+        blocks_count: u64,
+        first_meta_block_group: Option<u32>,
+    ) -> Superblock {
+        Superblock {
+            block_size: BlockSize::from_superblock_value(0).unwrap(),
+            blocks_count,
+            inode_size: 256,
+            inodes_per_block_group: NonZero::new(2048).unwrap(),
+            block_group_descriptor_size: 64,
+            first_data_block: 1,
+            blocks_per_group: 8192,
+            first_meta_block_group,
+            num_block_groups: u32::try_from(
+                blocks_count.saturating_sub(1).div_ceil(8192),
+            )
+            .unwrap(),
+            incompatible_features: IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY
+                | IncompatibleFeatures::EXTENTS
+                | IncompatibleFeatures::IS_64BIT,
+            read_only_compatible_features:
+                ReadOnlyCompatibleFeatures::SPARSE_SUPERBLOCKS,
+            checksum_seed: 0,
+            htree_hash_seed: [0; 4],
+            journal_inode: None,
+            label: Label::new([0; 16]),
+            uuid: Uuid::new([0; 16]),
+        }
+    }
+
+    /// `META_BLOCK_GROUPS` stores each descriptor block inside the groups it describes.
+    ///
+    /// The numbers come from `dumpe2fs` on a filesystem built with
+    /// `mke2fs -t ext4 -O meta_bg,^resize_inode -b 1024 -F img 1048576`, which reports the
+    /// descriptor blocks at 2, 8194, 122881, 131073, 139265, 253953, 262145, 270337, …
+    #[test]
+    fn meta_block_group_descriptor_locations() {
+        let sb = meta_bg_superblock(1_048_576, Some(0));
+        assert_eq!(sb.num_block_groups, 128);
+
+        // Meta block group 0 covers groups 0..15, and its block is in group 0 after the primary
+        // superblock: block 2.
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&sb, 0),
+            Some(2 * 1024)
+        );
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&sb, 15),
+            Some(2 * 1024 + 15 * 64)
+        );
+
+        // Meta block group 1 covers 16..31, and group 16 carries no superblock backup, so its
+        // block is that group's first: 131073.
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&sb, 16),
+            Some(131_073 * 1024)
+        );
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&sb, 31),
+            Some(131_073 * 1024 + 15 * 64)
+        );
+        // And meta block group 2.
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&sb, 32),
+            Some(262_145 * 1024)
+        );
+
+        // Without the feature the table is one run beginning after the superblock.
+        let old = meta_bg_superblock(1_048_576, None);
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&old, 0),
+            Some(2 * 1024)
+        );
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&old, 16),
+            Some(2 * 1024 + 16 * 64)
+        );
+
+        // `s_first_meta_bg` counts descriptor blocks, so blocks below it keep the old layout.
+        let mixed = meta_bg_superblock(1_048_576, Some(2));
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&mixed, 31),
+            Some(2 * 1024 + 31 * 64)
+        );
+        assert_eq!(
+            BlockGroupDescriptor::get_start_byte(&mixed, 32),
+            Some(262_145 * 1024)
+        );
+    }
+
+    /// The groups carrying a superblock backup are `SPARSE_SUPER`'s, which `META_BLOCK_GROUPS`
+    /// does not change — measured on the same filesystem, whose backups are in groups 0, 1, 3, 5,
+    /// 7, 9, 25, 27, 49, 81 and 125.
+    #[test]
+    fn superblock_backups_follow_sparse_super() {
+        let sparse: Vec<u32> = (0..128)
+            .filter(|g| BlockGroupDescriptor::group_has_superblock(*g))
+            .collect();
+        assert_eq!(sparse, [0, 1, 3, 5, 7, 9, 25, 27, 49, 81, 125]);
     }
 }

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -25,6 +25,16 @@ pub(crate) struct Superblock {
     pub(crate) inode_size: u16,
     pub(crate) inodes_per_block_group: NonZero<u32>,
     pub(crate) block_group_descriptor_size: u16,
+    /// First block of the filesystem's data: 1 when the block size is 1KiB, 0 otherwise.
+    pub(crate) first_data_block: u32,
+    pub(crate) blocks_per_group: u32,
+    /// With `META_BLOCK_GROUPS`, the first block-group-descriptor *block* stored in the
+    /// meta-block-group layout rather than in one run at the start of the filesystem. `None`
+    /// without the feature.
+    ///
+    /// Counted in descriptor blocks, not in block groups: e2fsprogs compares it against
+    /// `group / descriptors_per_block`.
+    pub(crate) first_meta_block_group: Option<u32>,
     pub(crate) num_block_groups: u32,
     pub(crate) incompatible_features: IncompatibleFeatures,
     pub(crate) read_only_compatible_features: ReadOnlyCompatibleFeatures,
@@ -55,6 +65,7 @@ impl Superblock {
         let s_blocks_per_group = read_u32le(bytes, 0x20);
         let s_inodes_per_group = read_u32le(bytes, 0x28);
         let s_magic = read_u16le(bytes, 0x38);
+        let s_first_meta_bg = read_u32le(bytes, 0x104);
         let s_inode_size = read_u16le(bytes, 0x58);
         let s_feature_compat = read_u32le(bytes, 0x5c);
         let s_feature_incompat = read_u32le(bytes, 0x60);
@@ -177,6 +188,15 @@ impl Superblock {
             inode_size: s_inode_size,
             inodes_per_block_group,
             block_group_descriptor_size,
+            first_data_block: s_first_data_block,
+            blocks_per_group: s_blocks_per_group,
+            first_meta_block_group: if incompatible_features
+                .contains(IncompatibleFeatures::META_BLOCK_GROUPS)
+            {
+                Some(s_first_meta_bg)
+            } else {
+                None
+            },
             num_block_groups,
             incompatible_features,
             read_only_compatible_features,
@@ -206,7 +226,6 @@ fn check_incompat_features(
     let required_features = IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY;
     let disallowed_features = IncompatibleFeatures::COMPRESSION
         | IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE
-        | IncompatibleFeatures::META_BLOCK_GROUPS
         | IncompatibleFeatures::MULTIPLE_MOUNT_PROTECTION
         | IncompatibleFeatures::LARGE_EXTENDED_ATTRIBUTES_IN_INODES
         | IncompatibleFeatures::DATA_IN_DIR_ENTRY
@@ -244,6 +263,9 @@ mod tests {
                 inode_size: 256,
                 inodes_per_block_group: NonZero::new(16).unwrap(),
                 block_group_descriptor_size: 64,
+                first_data_block: 1,
+                blocks_per_group: 8192,
+                first_meta_block_group: None,
                 num_block_groups: 1,
                 incompatible_features:
                     IncompatibleFeatures::FILE_TYPE_IN_DIR_ENTRY


### PR DESCRIPTION
`META_BLOCK_GROUPS` is in `disallowed_features`, so a filesystem carrying it cannot be opened at all. Filesystems carrying it are ordinary rather than exotic: `mke2fs` switches to the layout on its own whenever the contiguous group descriptor table stops fitting in one block group, which happens above about 1 TB with a 1 KiB block size. A 1.5 TB ext4 made on Linux with `-b 1024` cannot be read by this crate today.

The feature cuts the descriptor table into one block per meta block group — `block_size / descriptor_size` groups' worth, so 16 groups at 1 KiB and 64 at 4 KiB — and stores each block inside the groups it describes instead of in one run at the start of the filesystem. The kernel documentation states the placement: "a single block group descriptor block is placed at the beginning of the first, second, and last block groups in a meta-block group". `get_start_byte` returns the first of those three, which is the copy e2fsprogs treats as primary, at that group's first block plus one where the group carries a superblock backup.

`s_first_meta_bg` is compared against the descriptor *block* index rather than the block group number, which is what e2fsprogs' own header says about the argument to `ext2fs_descriptor_block_loc2`: "not actually a group number but a block number offset within a group table". `mke2fs` writes 0 there when it enables the feature, so the whole table moves; a contiguous prefix is what `resize2fs` leaves behind when it grows a filesystem into the layout, and that is handled too.

Superblock backups are unaffected — they stay where `SPARSE_SUPER` puts them. This is worth stating because the kernel documentation describes the superblock and the descriptor block as being placed together, and on a real filesystem they are not. Measured on a 1.5 TB `mke2fs -b 1024` filesystem: 196,608 block groups, 36,864 of them holding a copy of a descriptor block, and 26 holding a superblock backup — groups 0, 1, and the powers of three, five and seven.

Verification: the rule reproduces the location `dumpe2fs` reports for every one of those 196,608 groups, and for both copies in every meta block group, with no mismatches. Two shapes were checked, because the edge is the short one — a filesystem of 120 groups has a final meta block group covering groups 112..127 with only 112..119 in existence, and `mke2fs` writes two copies there rather than three, without moving the third to the last group that does exist.

The tests' numbers come from `mke2fs -t ext4 -O meta_bg,^resize_inode -b 1024 -F img 1048576`. The `^resize_inode` is not optional: `mke2fs` refuses the pair outright — "The resize_inode and meta_bg features are not compatible. They can not be both enabled simultaneously."

`Superblock` gains `first_data_block` and `blocks_per_group`, both of which it already read and discarded, because the group base is what the new layout is expressed in.

Written with AI assistance; I review every line and run the suite before sending anything.
