### PR TITLE
Add support for inode timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   and `Path`) to wrap the string in quotes, matching `std` behavior`.
 * Changed the `Debug` impl for `DirEntry` to just show the path,
   matching `std` behavior.
+* Added support for inode timestamps with a new `Timestamp` type.
 
 ## 0.9.3
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -302,6 +302,9 @@ pub(crate) enum CorruptKind {
     /// An inode's file type is invalid.
     InodeFileType { inode: InodeIndex, mode: InodeMode },
 
+    /// An inode's timestamp is invalid.
+    InodeTimestamp { inode: InodeIndex },
+
     /// The target of a symlink is not a valid path.
     SymlinkTarget(InodeIndex),
 
@@ -489,6 +492,9 @@ impl Display for CorruptKind {
                     "inode {inode} has invalid file type: mode=0x{mode:04x}",
                     mode = mode.bits()
                 )
+            }
+            Self::InodeTimestamp { inode } => {
+                write!(f, "inode {inode} has invalid timestamp",)
             }
             Self::SymlinkTarget(inode) => {
                 write!(f, "inode {inode} has an invalid symlink path")

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -13,6 +13,7 @@ use crate::error::{CorruptKind, Ext4Error};
 use crate::file_type::FileType;
 use crate::metadata::Metadata;
 use crate::path::PathBuf;
+use crate::timestamp::Timestamp;
 use crate::util::{
     read_u16le, read_u32le, u32_from_hilo, u64_from_hilo, usize_from_u32,
 };
@@ -118,6 +119,11 @@ impl Inode {
     const INLINE_DATA_LEN: usize = 60;
     const L_I_CHECKSUM_LO_OFFSET: usize = 0x74 + 0x8;
     const I_CHECKSUM_HI_OFFSET: usize = 0x82;
+    const I_CTIME_EXTRA_OFFSET: usize = 0x84;
+    const I_MTIME_EXTRA_OFFSET: usize = 0x88;
+    const I_ATIME_EXTRA_OFFSET: usize = 0x8c;
+    const I_CRTIME_OFFSET: usize = 0x90;
+    const I_CRTIME_EXTRA_OFFSET: usize = 0x94;
 
     /// Load an inode from `bytes`.
     ///
@@ -152,6 +158,9 @@ impl Inode {
         let i_mode = read_u16le(data, 0x0);
         let i_uid = read_u16le(data, 0x2);
         let i_size_lo = read_u32le(data, 0x4);
+        let i_atime = read_u32le(data, 0x8);
+        let i_ctime = read_u32le(data, 0xc);
+        let i_mtime = read_u32le(data, 0x10);
         let i_gid = read_u16le(data, 0x18);
         let i_flags = read_u32le(data, 0x20);
         // OK to unwrap: already checked the length.
@@ -171,6 +180,35 @@ impl Inode {
             // aren't used; arbitrarily set to zero.
             (0, 0)
         };
+
+        // Extra timestamps fields & creation time if inode large enough.
+        let (i_atime_extra, i_ctime_extra, i_mtime_extra, crtime) = if data
+            .len()
+            >= Self::I_CRTIME_EXTRA_OFFSET + 4
+        {
+            let i_atime_extra = read_u32le(data, Self::I_ATIME_EXTRA_OFFSET);
+            let i_ctime_extra = read_u32le(data, Self::I_CTIME_EXTRA_OFFSET);
+            let i_mtime_extra = read_u32le(data, Self::I_MTIME_EXTRA_OFFSET);
+            let i_crtime = read_u32le(data, Self::I_CRTIME_OFFSET);
+            let i_crtime_extra = read_u32le(data, Self::I_CRTIME_EXTRA_OFFSET);
+            let crtime = Timestamp::from_raw(i_crtime, Some(i_crtime_extra))
+                .map_err(|_| CorruptKind::InodeTimestamp { inode: index })?;
+            (
+                Some(i_atime_extra),
+                Some(i_ctime_extra),
+                Some(i_mtime_extra),
+                Some(crtime),
+            )
+        } else {
+            (None, None, None, None)
+        };
+
+        let atime = Timestamp::from_raw(i_atime, i_atime_extra)
+            .map_err(|_| CorruptKind::InodeTimestamp { inode: index })?;
+        let ctime = Timestamp::from_raw(i_ctime, i_ctime_extra)
+            .map_err(|_| CorruptKind::InodeTimestamp { inode: index })?;
+        let mtime = Timestamp::from_raw(i_mtime, i_mtime_extra)
+            .map_err(|_| CorruptKind::InodeTimestamp { inode: index })?;
 
         let size_in_bytes = u64_from_hilo(i_size_high, i_size_lo);
         let uid = u32_from_hilo(l_i_uid_high, i_uid);
@@ -203,6 +241,10 @@ impl Inode {
                     file_type: FileType::try_from(mode).map_err(|_| {
                         CorruptKind::InodeFileType { inode: index, mode }
                     })?,
+                    atime,
+                    ctime,
+                    mtime,
+                    crtime,
                 },
                 flags: InodeFlags::from_bits_retain(i_flags),
                 checksum_base,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@ mod path;
 mod reader;
 mod resolve;
 mod superblock;
+mod timestamp;
 mod util;
 mod uuid;
 
@@ -167,6 +168,7 @@ pub use label::Label;
 pub use metadata::Metadata;
 pub use path::{Component, Components, Path, PathBuf, PathError};
 pub use reader::{Ext4Read, MemIoError};
+pub use timestamp::Timestamp;
 pub use uuid::Uuid;
 
 struct Ext4Inner {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -8,6 +8,7 @@
 
 use crate::file_type::FileType;
 use crate::inode::InodeMode;
+use crate::timestamp::Timestamp;
 
 /// Metadata information about a file.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -26,6 +27,19 @@ pub struct Metadata {
 
     /// Owner group ID.
     pub(crate) gid: u32,
+
+    /// Last access time.
+    pub(crate) atime: Timestamp,
+
+    /// Last inode change time.
+    pub(crate) ctime: Timestamp,
+
+    /// Last data modification time.
+    pub(crate) mtime: Timestamp,
+
+    /// Creation time.
+    /// Only present if inode is large enough.
+    pub(crate) crtime: Option<Timestamp>,
 }
 
 impl Metadata {
@@ -90,5 +104,23 @@ impl Metadata {
     #[must_use]
     pub fn gid(&self) -> u32 {
         self.gid
+    }
+
+    /// Last access time.
+    #[must_use]
+    pub fn accessed(&self) -> Timestamp {
+        self.atime
+    }
+
+    /// Last data modification time.
+    #[must_use]
+    pub fn modified(&self) -> Timestamp {
+        self.mtime
+    }
+
+    /// Creation time.
+    #[must_use]
+    pub fn created(&self) -> Option<Timestamp> {
+        self.crtime
     }
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TimestampError;
+
+/// Timestamps associated with an inode, relative time to EPOCH.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Timestamp {
+    seconds: i64,
+    nanoseconds: u32,
+}
+
+impl Timestamp {
+    /// Seconds since EPOCH.
+    #[must_use]
+    pub fn seconds(self) -> i64 {
+        self.seconds
+    }
+
+    /// Nanoseconds within the second.
+    #[must_use]
+    pub fn nanoseconds(self) -> u32 {
+        self.nanoseconds
+    }
+
+    /// Decode a timestamp from the base field in the classic 128-byte
+    /// inode, plus the corresponding `*_extra` field if present.
+    pub(crate) fn from_raw(
+        secs: u32,
+        extra: Option<u32>,
+    ) -> Result<Self, TimestampError> {
+        let mut seconds =
+            i64::from(i32::try_from(secs).map_err(|_| TimestampError)?);
+        let mut nanoseconds = 0;
+
+        if let Some(extra) = extra {
+            // The lower two bits extend the seconds, the higher 30 bits hold
+            // nanoseconds.
+            seconds = seconds
+                .checked_add(i64::from(extra & 0x3) << 32)
+                .ok_or(TimestampError)?;
+            nanoseconds = extra >> 2;
+
+            // Ensure nanoseconds are valid.
+            if nanoseconds >= 1_000_000_000 {
+                return Err(TimestampError);
+            }
+        }
+
+        Ok(Self {
+            seconds,
+            nanoseconds,
+        })
+    }
+}

--- a/tests/integration/ext2.rs
+++ b/tests/integration/ext2.rs
@@ -47,3 +47,15 @@ fn test_read_file_with_holes() {
 
     assert_eq!(fs.read("/holes").unwrap(), expected_holes_data());
 }
+
+#[test]
+fn test_timestamps() {
+    let fs = load_ext2();
+    let metadata = fs.metadata("/big_file").unwrap();
+    assert_eq!(metadata.accessed().seconds(), 1735776533);
+    assert_eq!(metadata.accessed().nanoseconds(), 928309932);
+    assert_eq!(metadata.modified().seconds(), 1735776533);
+    assert_eq!(metadata.modified().nanoseconds(), 929309821);
+    assert_eq!(metadata.created().unwrap().seconds(), 1735776533);
+    assert_eq!(metadata.created().unwrap().nanoseconds(), 928309932);
+}

--- a/tests/integration/ext3.rs
+++ b/tests/integration/ext3.rs
@@ -34,3 +34,14 @@ fn test_tea_htree() {
         assert_eq!(fs.read_to_string(&medium_dir.join(&i)).unwrap(), i);
     }
 }
+
+#[test]
+fn test_timestamps() {
+    let fs = load_ext3();
+    let metadata = fs.metadata("/medium_dir/42").unwrap();
+    assert_eq!(metadata.accessed().seconds(), 1765162262);
+    assert_eq!(metadata.accessed().nanoseconds(), 0);
+    assert_eq!(metadata.modified().seconds(), 1765162262);
+    assert_eq!(metadata.modified().nanoseconds(), 0);
+    assert_eq!(metadata.created(), None);
+}

--- a/tests/integration/ext4.rs
+++ b/tests/integration/ext4.rs
@@ -300,6 +300,19 @@ fn test_metadata_uid_gid() {
 }
 
 #[test]
+fn test_metadata_timestamps() {
+    let fs = load_test_disk1();
+
+    let metadata = fs.metadata("/owner_file").unwrap();
+    assert_eq!(metadata.accessed().seconds(), 1736997889);
+    assert_eq!(metadata.accessed().nanoseconds(), 521951155);
+    assert_eq!(metadata.modified().seconds(), 1736997889);
+    assert_eq!(metadata.modified().nanoseconds(), 521951155);
+    assert_eq!(metadata.created().unwrap().seconds(), 1736997889);
+    assert_eq!(metadata.created().unwrap().nanoseconds(), 521951155);
+}
+
+#[test]
 fn test_direntry_debug() {
     let fs = load_test_disk1();
     let entry = fs


### PR DESCRIPTION
Hello, thank you for this crate.

I added timestamps support based on https://docs.kernel.org/filesystems/ext4/inodes.html#inode-timestamps.

Let me know if you need changes.