### PR TITLE
Upgrade to sha2-0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +51,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -149,6 +164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,13 +207,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "digest-io"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de63d600bc7fab91180bc17385f29b342468dc8ef2af09dceba450a293de3da"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -350,6 +402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,7 +522,7 @@ checksum = "acc1627ccb67ec2a931d34b5e97840c6f184f58cd2797ae253e848c58aea38a9"
 dependencies = [
  "log",
  "lzma-rs",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "ureq",
 ]
@@ -658,8 +719,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -771,8 +843,9 @@ dependencies = [
 name = "uefibench"
 version = "0.0.0"
 dependencies = [
+ "base16ct",
  "ext4-view",
- "sha2",
+ "sha2 0.11.0",
  "uefi",
 ]
 
@@ -1108,14 +1181,16 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "base16ct",
  "clap",
+ "digest-io",
  "ext4-view",
  "gpt_disk_io",
  "libc",
  "lzma-rs",
  "nix",
  "ovmf-prebuilt",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "tempfile",
  "ureq",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,15 +46,6 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -155,13 +146,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cpufeatures"
@@ -198,16 +186,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -217,22 +195,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
 ]
 
 [[package]]
@@ -241,7 +210,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de63d600bc7fab91180bc17385f29b342468dc8ef2af09dceba450a293de3da"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -307,16 +276,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -516,13 +475,14 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "ovmf-prebuilt"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc1627ccb67ec2a931d34b5e97840c6f184f58cd2797ae253e848c58aea38a9"
+checksum = "8b2ed5d406bc56f93035547fe364feb90395682dd8cc9efea09e806f8f845a17"
 dependencies = [
+ "base16ct",
  "log",
  "lzma-rs",
- "sha2 0.10.9",
+ "sha2",
  "tar",
  "ureq",
 ]
@@ -714,24 +674,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.1",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -845,7 +794,7 @@ version = "0.0.0"
 dependencies = [
  "base16ct",
  "ext4-view",
- "sha2 0.11.0",
+ "sha2",
  "uefi",
 ]
 
@@ -910,12 +859,6 @@ name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1190,7 +1133,7 @@ dependencies = [
  "lzma-rs",
  "nix",
  "ovmf-prebuilt",
- "sha2 0.11.0",
+ "sha2",
  "tar",
  "tempfile",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.0", features = ["backtrace"] }
+sha2 = { version = "0.10.8", default-features = false }
 
 [features]
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.0", features = ["backtrace"] }
-sha2 = { version = "0.10.8", default-features = false }
+base16ct = "1.0.0"
+sha2 = { version = "0.11.0", default-features = false }
 
 [features]
 std = []

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2.155"
 lzma-rs = "0.3.0"
 nix = { version = "0.31.0", features = ["fs", "user"] }
 ovmf-prebuilt = "0.2.2"
-sha2 = "0.10.8"
+sha2.workspace = true
 tar = "0.4.40"
 tempfile = "3.10.1"
 ureq = "3.0.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,7 +16,9 @@ default-run = "xtask"
 
 [dependencies]
 anyhow.workspace = true
+base16ct.workspace = true
 clap = { version = "4.5.0", default-features = false, features = ["derive", "help", "std"] }
+digest-io = "0.1.0"
 ext4-view = { path = "../", features = ["std"] }
 gpt_disk_io = { version = "0.16.0", features = ["std"] }
 libc = "0.2.155"

--- a/xtask/src/bench/walk.rs
+++ b/xtask/src/bench/walk.rs
@@ -9,8 +9,9 @@
 // Note: this file is used as a module in `bench.rs`, but is also used
 // via an `include!` in `xtask/uefibench`.
 
-use alloc::string::String;
-use alloc::{format, vec};
+use alloc::string::{String, ToString};
+use alloc::vec;
+use base16ct::HexDisplay;
 use ext4_view::{Ext4, Ext4Error, File, Path};
 use sha2::{Digest, Sha256};
 
@@ -21,7 +22,7 @@ use sha2::{Digest, Sha256};
 pub fn walk(fs: &Ext4) -> Result<String, Ext4Error> {
     let mut hash = Sha256::new();
     walk_impl(fs, Path::ROOT, &mut hash)?;
-    Ok(format!("{:x}", hash.finalize()))
+    Ok(HexDisplay(&hash.finalize()).to_string())
 }
 
 fn walk_impl(

--- a/xtask/src/big_fs.rs
+++ b/xtask/src/big_fs.rs
@@ -51,7 +51,7 @@ pub fn download_big_filesystems() -> Result<()> {
     let board = "amd64-generic-public";
     let version = "R127-15907.0.0";
     let expected_sha256 =
-        "9e1b25a4e509c9fccd62d074d963e0fda718ef0e06403e9a0a0804eb90a53b31";
+        "9E1B25A4E509C9FCCD62D074D963E0FDA718EF0E06403E9A0A0804EB90A53B31";
 
     let url = format!(
         "https://storage.googleapis.com/{bucket}/{board}/{version}/{compressed_file_name}"

--- a/xtask/src/diff_walk.rs
+++ b/xtask/src/diff_walk.rs
@@ -8,6 +8,7 @@
 
 use crate::{capture_cmd, run_cmd, sudo};
 use anyhow::{Result, bail};
+use base16ct::HexDisplay;
 use ext4_view::{Ext4, Ext4Error};
 use sha2::{Digest, Sha256};
 use std::env;
@@ -84,7 +85,7 @@ fn new_dir_entry(
         FileContent::Dir
     } else {
         let data = fs.read(&path)?;
-        let hash = format!("{:x}", Sha256::digest(data));
+        let hash = HexDisplay(&Sha256::digest(data)).to_string();
         FileContent::Regular(hash)
     };
     Ok(WalkDirEntry {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -9,6 +9,8 @@
 mod mount;
 
 use anyhow::{Context, Result, bail};
+use base16ct::HexDisplay;
+use digest_io::IoWrapper;
 use sha2::Digest;
 use sha2::Sha256;
 use std::fs::File;
@@ -25,10 +27,9 @@ pub use mount::{Mount, ReadOnly};
 /// loaded into memory all at once.
 pub fn calc_file_sha256(path: &Path) -> Result<String> {
     let mut file = File::open(path)?;
-    let mut hasher = Sha256::new();
+    let mut hasher = IoWrapper(Sha256::new());
     io::copy(&mut file, &mut hasher)?;
-    let hash = hasher.finalize();
-    Ok(format!("{hash:x}"))
+    Ok(HexDisplay(&hasher.0.finalize()).to_string())
 }
 
 fn cmd_to_string(cmd: &Command) -> String {

--- a/xtask/uefibench/Cargo.toml
+++ b/xtask/uefibench/Cargo.toml
@@ -8,7 +8,7 @@ autotests = false
 
 [dependencies]
 ext4-view = { path = "../.." }
-sha2 = { version = "0.10.8", default-features = false }
+sha2.workspace = true
 uefi = { version = "0.40.0", features = ["alloc"] }
 
 [target.'cfg(target_os = "uefi")'.dependencies]

--- a/xtask/uefibench/Cargo.toml
+++ b/xtask/uefibench/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 autotests = false
 
 [dependencies]
+base16ct.workspace = true
 ext4-view = { path = "../.." }
 sha2.workspace = true
 uefi = { version = "0.40.0", features = ["alloc"] }


### PR DESCRIPTION
This requires adding `digest-io` so that the digest works with `io::copy`. And it requires adding `base16ct` so that the digest can be formatted as hex.

I find the design of the `sha2` crate frustrating, but I didn't see a good replacement on crates.io, so sticking with it for now.