### PR TITLE
Add inode timestamps to Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added `Metadata::accessed`, `changed`, `modified` and `created`, returning
+  the inode's timestamps as a new `Timestamp` type (seconds and
+  nanoseconds, with the extra epoch bits of large inodes applied).
 * MSRV increased to `1.85`.
 * Improved error messages for various directory entry corruption errors.
 * Changed the `Debug` impls for stringish types (such as `DirEntryName`

--- a/src/inode.rs
+++ b/src/inode.rs
@@ -11,7 +11,7 @@ use crate::block_index::FsBlockIndex;
 use crate::checksum::Checksum;
 use crate::error::{CorruptKind, Ext4Error};
 use crate::file_type::FileType;
-use crate::metadata::Metadata;
+use crate::metadata::{Metadata, Timestamp};
 use crate::path::PathBuf;
 use crate::util::{
     read_u16le, read_u32le, u32_from_hilo, u64_from_hilo, usize_from_u32,
@@ -152,6 +152,9 @@ impl Inode {
         let i_mode = read_u16le(data, 0x0);
         let i_uid = read_u16le(data, 0x2);
         let i_size_lo = read_u32le(data, 0x4);
+        let i_atime = read_u32le(data, 0x8);
+        let i_ctime = read_u32le(data, 0xc);
+        let i_mtime = read_u32le(data, 0x10);
         let i_gid = read_u16le(data, 0x18);
         let i_flags = read_u32le(data, 0x20);
         // OK to unwrap: already checked the length.
@@ -171,6 +174,27 @@ impl Inode {
             // aren't used; arbitrarily set to zero.
             (0, 0)
         };
+
+        // The extra fields after the 128-byte inode, when the inode is
+        // large enough and `i_extra_isize` covers them.
+        let extra_end = if data.len() >= 0x82 {
+            usize::from(read_u16le(data, 0x80)).saturating_add(0x80)
+        } else {
+            0
+        };
+        let extra_u32 = |offset: usize| -> Option<u32> {
+            let end = offset.checked_add(4)?;
+            if end <= extra_end && end <= data.len() {
+                Some(read_u32le(data, offset))
+            } else {
+                None
+            }
+        };
+        let atime = Timestamp::from_raw(i_atime, extra_u32(0x8c));
+        let ctime = Timestamp::from_raw(i_ctime, extra_u32(0x84));
+        let mtime = Timestamp::from_raw(i_mtime, extra_u32(0x88));
+        let crtime = extra_u32(0x90)
+            .map(|seconds| Timestamp::from_raw(seconds, extra_u32(0x94)));
 
         let size_in_bytes = u64_from_hilo(i_size_high, i_size_lo);
         let uid = u32_from_hilo(l_i_uid_high, i_uid);
@@ -203,6 +227,10 @@ impl Inode {
                     file_type: FileType::try_from(mode).map_err(|_| {
                         CorruptKind::InodeFileType { inode: index, mode }
                     })?,
+                    atime,
+                    ctime,
+                    mtime,
+                    crtime,
                 },
                 flags: InodeFlags::from_bits_retain(i_flags),
                 checksum_base,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub use file_type::FileType;
 pub use format::BytesDisplay;
 pub use iters::read_dir::ReadDir;
 pub use label::Label;
-pub use metadata::Metadata;
+pub use metadata::{Metadata, Timestamp};
 pub use path::{Component, Components, Path, PathBuf, PathError};
 pub use reader::{Ext4Read, MemIoError};
 pub use uuid::Uuid;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -9,6 +9,39 @@
 use crate::file_type::FileType;
 use crate::inode::InodeMode;
 
+/// A point in time recorded in an inode: seconds since the Unix epoch
+/// (negative for times before it) and nanoseconds within that second.
+///
+/// Inodes of 128 bytes store only whole seconds in a 32-bit field; larger
+/// inodes may carry two more bits of seconds (extending the range to the
+/// year 2446) and the nanoseconds.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Timestamp {
+    /// Whole seconds since 1970-01-01T00:00:00Z.
+    pub seconds: i64,
+    /// Nanoseconds within the second, less than one billion.
+    pub nanoseconds: u32,
+}
+
+impl Timestamp {
+    /// Decode a timestamp from the base 32-bit seconds field and the
+    /// optional extra field (the low two bits extend the seconds, the
+    /// rest are nanoseconds), as Linux does.
+    pub(crate) fn from_raw(seconds: u32, extra: Option<u32>) -> Self {
+        // The base field is signed: it covers 1901 to 2038 on its own.
+        let mut seconds = i64::from(i32::from_le_bytes(seconds.to_le_bytes()));
+        let mut nanoseconds = 0;
+        if let Some(extra) = extra {
+            seconds = seconds.saturating_add(i64::from(extra & 0b11) << 32);
+            nanoseconds = (extra >> 2).min(999_999_999);
+        }
+        Self {
+            seconds,
+            nanoseconds,
+        }
+    }
+}
+
 /// Metadata information about a file.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Metadata {
@@ -26,9 +59,47 @@ pub struct Metadata {
 
     /// Owner group ID.
     pub(crate) gid: u32,
+
+    /// Last access time.
+    pub(crate) atime: Timestamp,
+
+    /// Last inode change time.
+    pub(crate) ctime: Timestamp,
+
+    /// Last data modification time.
+    pub(crate) mtime: Timestamp,
+
+    /// Creation time, if the inode is large enough to record it.
+    pub(crate) crtime: Option<Timestamp>,
 }
 
 impl Metadata {
+    /// Get the last access time.
+    #[must_use]
+    pub fn accessed(&self) -> Timestamp {
+        self.atime
+    }
+
+    /// Get the last inode change time (the `ctime`: when the metadata or
+    /// the data last changed).
+    #[must_use]
+    pub fn changed(&self) -> Timestamp {
+        self.ctime
+    }
+
+    /// Get the last data modification time.
+    #[must_use]
+    pub fn modified(&self) -> Timestamp {
+        self.mtime
+    }
+
+    /// Get the creation time, if the inode records one (inodes of 128
+    /// bytes, as `mke2fs -I 128` or old filesystems have them, do not).
+    #[must_use]
+    pub fn created(&self) -> Option<Timestamp> {
+        self.crtime
+    }
+
     /// Get the file type.
     #[must_use]
     pub fn file_type(&self) -> FileType {
@@ -90,5 +161,33 @@ impl Metadata {
     #[must_use]
     pub fn gid(&self) -> u32 {
         self.gid
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timestamp_from_raw() {
+        // Whole seconds only.
+        assert_eq!(
+            Timestamp::from_raw(1_700_000_000, None),
+            Timestamp {
+                seconds: 1_700_000_000,
+                nanoseconds: 0
+            }
+        );
+        // A time before the epoch: the base field is signed.
+        assert_eq!(Timestamp::from_raw(0xffff_ffff, None).seconds, -1);
+        // The extra field: two epoch bits and the nanoseconds.
+        let extra = (123_456_789u32 << 2) | 0b01;
+        assert_eq!(
+            Timestamp::from_raw(0xffff_ffff, Some(extra)),
+            Timestamp {
+                seconds: -1 + (1 << 32),
+                nanoseconds: 123_456_789
+            }
+        );
     }
 }


### PR DESCRIPTION
This exposes the access, change, modification and creation times of an inode through `Metadata::accessed`, `changed`, `modified` and `created`, as a new `Timestamp` type (seconds since the epoch and nanoseconds).

Large inodes carry two extra epoch bits and the nanoseconds in the fields after `i_extra_isize`; those are applied when `i_extra_isize` covers the field, as Linux does. `created` is `None` for 128-byte inodes, which have no room for it. The base 32-bit field is treated as signed, so times before 1970 come out negative rather than as the year 2100.

Motivation: an archive browser listing an ext4 image needs the modification times next to the sizes. A unit test covers the decoding of the raw fields.