### PR TITLE
Add missing check for invalid s_desc_size in superblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 * MSRV increased to `1.85`.
 * Improved error messages for various directory entry corruption errors.
 * Changed the `Debug` impls for stringish types (such as `DirEntryName`
-  and `Path`) to wrap the string in quotes, matching `std` behavior`.
+  and `Path`) to wrap the string in quotes, matching `std` behavior.
 * Changed the `Debug` impl for `DirEntry` to just show the path,
   matching `std` behavior.
 * Added support for inode timestamps with a new `Timestamp` type.
+* Fixed some panics when loading corrupt file systems.
 
 ## 0.9.3
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -203,6 +203,9 @@ pub(crate) enum CorruptKind {
     /// The number of inodes per block group is zero.
     InodesPerBlockGroup,
 
+    /// The block group descriptor size in the superblock is invalid.
+    BlockGroupDescriptorSize,
+
     /// The number of blocks per group is zero.
     BlocksPerGroup,
 
@@ -397,6 +400,9 @@ impl Display for CorruptKind {
             Self::TooManyBlockGroups => write!(f, "too many block groups"),
             Self::InodesPerBlockGroup => {
                 write!(f, "inodes per block group is zero")
+            }
+            Self::BlockGroupDescriptorSize => {
+                write!(f, "invalid block group descriptor size")
             }
             Self::BlocksPerGroup => {
                 write!(f, "blocks per group is zero")

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -117,6 +117,9 @@ impl Superblock {
 
         let block_group_descriptor_size =
             if incompatible_features.contains(IncompatibleFeatures::IS_64BIT) {
+                if s_desc_size < 64 {
+                    return Err(CorruptKind::BlockGroupDescriptorSize.into());
+                }
                 s_desc_size
             } else {
                 32
@@ -430,7 +433,6 @@ mod tests {
     /// crashing.
     #[cfg(feature = "std")]
     #[test]
-    #[should_panic]
     fn test_invalid_s_desc_size() {
         let mut data =
             crate::test_util::load_compressed_data("test_disk1.bin.zst");
@@ -452,6 +454,9 @@ mod tests {
         data[superblock_start + Superblock::S_DESC_SIZE_OFFSET..][..2]
             .copy_from_slice(&1u16.to_le_bytes());
 
-        crate::Ext4::load(Box::new(data)).unwrap();
+        assert_eq!(
+            crate::Ext4::load(Box::new(data)).unwrap_err(),
+            CorruptKind::BlockGroupDescriptorSize
+        );
     }
 }

--- a/src/superblock.rs
+++ b/src/superblock.rs
@@ -39,6 +39,9 @@ impl Superblock {
     /// Size (in bytes) of the superblock on disk.
     pub(crate) const SIZE_IN_BYTES_ON_DISK: usize = 1024;
 
+    const S_FEATURE_RO_COMPAT_OFFSET: usize = 0x64;
+    const S_DESC_SIZE_OFFSET: usize = 0xfe;
+
     /// Construct `Superblock` from bytes.
     ///
     /// # Panics
@@ -58,7 +61,8 @@ impl Superblock {
         let s_inode_size = read_u16le(bytes, 0x58);
         let s_feature_compat = read_u32le(bytes, 0x5c);
         let s_feature_incompat = read_u32le(bytes, 0x60);
-        let s_feature_ro_compat = read_u32le(bytes, 0x64);
+        let s_feature_ro_compat =
+            read_u32le(bytes, Self::S_FEATURE_RO_COMPAT_OFFSET);
         let s_uuid = &bytes[0x68..0x68 + 16];
         let s_volume_name = &bytes[0x78..0x78 + 16];
         let s_journal_inum = read_u32le(bytes, 0xe0);
@@ -69,7 +73,7 @@ impl Superblock {
             read_u32le(bytes, S_HASH_SEED_OFFSET + 8),
             read_u32le(bytes, S_HASH_SEED_OFFSET + 12),
         ];
-        let s_desc_size = read_u16le(bytes, 0xfe);
+        let s_desc_size = read_u16le(bytes, Self::S_DESC_SIZE_OFFSET);
         let s_blocks_count_hi = read_u32le(bytes, 0x150);
         let s_checksum_seed = read_u32le(bytes, 0x270);
         const S_CHECKSUM_OFFSET: usize = 0x3fc;
@@ -420,5 +424,34 @@ mod tests {
                 IncompatibleFeatures::SEPARATE_JOURNAL_DEVICE
             )
         );
+    }
+
+    /// Test that an invalid `s_desc_size` produces an error rather than
+    /// crashing.
+    #[cfg(feature = "std")]
+    #[test]
+    #[should_panic]
+    fn test_invalid_s_desc_size() {
+        let mut data =
+            crate::test_util::load_compressed_data("test_disk1.bin.zst");
+        let superblock_start = 1024;
+
+        // Turn off checksums to make the filesystem easier to modify.
+        let mut s_feature_ro_compat = u32::from_le_bytes(
+            data[superblock_start + Superblock::S_FEATURE_RO_COMPAT_OFFSET..]
+                [..4]
+                .try_into()
+                .unwrap(),
+        );
+        s_feature_ro_compat &=
+            !ReadOnlyCompatibleFeatures::METADATA_CHECKSUMS.bits();
+        data[superblock_start + Superblock::S_FEATURE_RO_COMPAT_OFFSET..][..4]
+            .copy_from_slice(&s_feature_ro_compat.to_le_bytes());
+
+        // Set `s_desc_size`.
+        data[superblock_start + Superblock::S_DESC_SIZE_OFFSET..][..2]
+            .copy_from_slice(&1u16.to_le_bytes());
+
+        crate::Ext4::load(Box::new(data)).unwrap();
     }
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -11,9 +11,9 @@
 
 use super::Ext4;
 
-/// Decompress a file with zstd, then load it into an `Ext4`.
-pub(crate) fn load_compressed_filesystem(name: &str) -> Ext4 {
-    // This function executes quickly, so don't bother caching.
+/// Decompress a file into memory with zstd.
+pub(crate) fn load_compressed_data(name: &str) -> Vec<u8> {
+    // This operation executes quickly, so don't bother caching.
     let output = std::process::Command::new("zstd")
         .args([
             "--decompress",
@@ -24,7 +24,13 @@ pub(crate) fn load_compressed_filesystem(name: &str) -> Ext4 {
         .output()
         .unwrap();
     assert!(output.status.success());
-    Ext4::load(Box::new(output.stdout)).unwrap()
+    output.stdout
+}
+
+/// Decompress a file with zstd, then load it into an `Ext4`.
+pub(crate) fn load_compressed_filesystem(name: &str) -> Ext4 {
+    let bytes = load_compressed_data(name);
+    Ext4::load(Box::new(bytes)).unwrap()
 }
 
 pub(crate) fn load_test_disk1() -> Ext4 {


### PR DESCRIPTION
Previously, an invalid `s_desc_size` would cause a crash on load. Now it returns a `CorruptKind` error instead.